### PR TITLE
feat: switch AI model to gemma-4-26b-a4b-it and increase input context to 32K chars

### DIFF
--- a/src/pages/api/ai-chat.ts
+++ b/src/pages/api/ai-chat.ts
@@ -92,7 +92,7 @@ ${trimmedContent}
     const stream = await env.AI.run(model, {
       messages: allMessages,
       stream: true,
-      max_tokens: 512,
+      max_completion_tokens: 1024,
     });
 
     return new Response(stream as ReadableStream, {

--- a/src/pages/api/ai-chat.ts
+++ b/src/pages/api/ai-chat.ts
@@ -4,7 +4,10 @@ import type { APIRoute } from "astro";
 export const prerender = false;
 
 // Maximum characters of post content to send (keeps us well within the 7968 token context window)
-const MAX_CONTENT_LENGTH = 6000;
+// gemma-4-26b-a4b-it supports a 256K token context window (~1M chars).
+// 32,000 chars (~8,000 tokens) covers even the longest blog posts while keeping costs low.
+// Raise this if posts are truncated, or lower it to reduce per-request token cost.
+const MAX_CONTENT_LENGTH = 32_000;
 
 export const POST: APIRoute = async ({ request }) => {
   // Only accept JSON
@@ -80,14 +83,12 @@ ${trimmedContent}
 
   try {
     // Model is configurable via the AI_MODEL var in wrangler.jsonc (no code change needed to swap models).
-    // Default: @cf/meta/llama-3.1-8b-instruct-fp8
-    // Pricing (as of Apr 2026): $0.152 per M input tokens, $0.287 per M output tokens
-    //   = 13,778 neurons/M input tokens, 26,128 neurons/M output tokens
-    // Free tier: 10,000 neurons/day (~270 summarizations/day at default model's rate)
-    // Paid tier: $0.011 per 1,000 neurons above the free daily allocation
+    // Default: @cf/google/gemma-4-26b-a4b-it
+    //   - Context window: 256,000 tokens; supports reasoning, function calling, and vision
+    //   - Pricing (as of Apr 2026): $0.10 per M input tokens, $0.30 per M output tokens
     // See available models: https://developers.cloudflare.com/workers-ai/models/
     // See pricing: https://developers.cloudflare.com/workers-ai/platform/pricing/
-    const model = (env.AI_MODEL ?? "@cf/meta/llama-3.1-8b-instruct-fp8") as Parameters<typeof env.AI.run>[0];
+    const model = (env.AI_MODEL ?? "@cf/google/gemma-4-26b-a4b-it") as Parameters<typeof env.AI.run>[0];
     const stream = await env.AI.run(model, {
       messages: allMessages,
       stream: true,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,6 +17,6 @@
 		// AI model to use for post summarization and Q&A.
 		// Change this to try a different model without redeploying code.
 		// See available models: https://developers.cloudflare.com/workers-ai/models/
-		"AI_MODEL": "@cf/meta/llama-3.1-8b-instruct-fp8"
+		"AI_MODEL": "@cf/google/gemma-4-26b-a4b-it"
 	}
 }


### PR DESCRIPTION
## Summary

Switches the default Workers AI model from `@cf/meta/llama-3.1-8b-instruct-fp8` to `@cf/google/gemma-4-26b-a4b-it` and increases the blog post input context limit to match the new model's capabilities.

Closes https://github.com/hossain-khan/hossains-dev-bytes/issues/16

## Changes

### `wrangler.jsonc`
- Updated `AI_MODEL` var default to `@cf/google/gemma-4-26b-a4b-it`

### `src/pages/api/ai-chat.ts`
- Updated default model fallback string to `@cf/google/gemma-4-26b-a4b-it`
- Increased `MAX_CONTENT_LENGTH` from `6,000` → `32,000` characters (~8,000 tokens)
- Updated pricing comment to reflect new model rates

## Why gemma-4-26b-a4b-it?

| | llama-3.1-8b-instruct-fp8 | gemma-4-26b-a4b-it |
|---|---|---|
| Context window | ~8K tokens | **256K tokens** |
| Reasoning | No | **Yes** |
| Function calling | No | **Yes** |
| Input pricing | $0.152/M tokens | **$0.10/M tokens** |
| Output pricing | $0.287/M tokens | $0.30/M tokens |

The larger context window means the full content of long blog posts can be passed to the model without truncation, leading to more accurate summaries and Q&A answers.

## Cost impact

At $0.10/M input tokens, sending 8,000 tokens costs ~$0.0008 per request — negligible. The model is also cheaper per input token than the previous default.

## Notes
- The model is still configurable via `AI_MODEL` in `wrangler.jsonc` or via Cloudflare Dashboard environment variables — no code change needed to switch models.