### PR TITLE
feat: render inline code backticks in AI response

### DIFF
--- a/src/components/AiPostAssistant.astro
+++ b/src/components/AiPostAssistant.astro
@@ -288,8 +288,13 @@
               `<code>${escapeHtml(code)}</code></pre>`
             );
           }
-          // Regular text — escape HTML and preserve newlines
-          return `<span class="whitespace-pre-wrap">${escapeHtml(part)}</span>`;
+          // Regular text — escape HTML, render inline code, and preserve newlines
+          const escaped = escapeHtml(part);
+          const withInlineCode = escaped.replace(
+            /`([^`]+)`/g,
+            `<code class="rounded px-1 py-0.5 text-[0.8em] font-mono bg-accent/10 text-accent/90 border border-border/20">$1</code>`
+          );
+          return `<span class="whitespace-pre-wrap">${withInlineCode}</span>`;
         })
         .join("");
     }


### PR DESCRIPTION
Follow-up to #20. Single-backtick inline code (e.g. `` `src/_worker.js` ``) is now rendered as a styled `<code>` element instead of raw backtick text.

## Changes
- In `renderMarkdown()`, regular text segments are now processed with a second pass that replaces `` `...` `` with `<code>` elements styled with an accent-colored pill
- Runs after `escapeHtml()` so content is already safe before the regex substitution (XSS safe)
- Triple-backtick fenced blocks are unaffected — they are split out before this pass runs