### PR TITLE
fix: render inline markdown inside list items (bold, italic, code)

### DIFF
--- a/src/components/AiPostAssistant.astro
+++ b/src/components/AiPostAssistant.astro
@@ -296,11 +296,15 @@
         ? "my-2 ml-4 list-decimal space-y-1"
         : "my-2 ml-4 list-disc space-y-1";
       const items = (token as { items?: { text: string }[] }).items ?? [];
-      const body = items.map(item => `<li class="leading-relaxed">${item.text}</li>`).join("");
+      // Use marked.parseInline to render bold/italic/code within each item's text
+      const body = items
+        .map(
+          item =>
+            `<li class="leading-relaxed">${marked.parseInline(item.text)}</li>`
+        )
+        .join("");
       return `<${tag} class="${cls}">${body}</${tag}>`;
     };
-    renderer.listitem = ({ text }) =>
-      `<li class="leading-relaxed">${text}</li>`;
     renderer.heading = ({ text, depth }) => {
       const cls =
         depth === 1 ? "text-base font-bold mt-3 mb-1" :


### PR DESCRIPTION
## Bug

In the AI Post Assistant, list items containing inline markdown (`**bold**`, `_italic_`, `` `code` ``) were rendered as raw text with literal asterisks/backticks.

**Root cause**: In the custom `list` renderer, `item.text` is the **raw markdown source** of the list item, not rendered HTML. The inline tokens (strong, em, codespan) were never processed for list item content.

**Example** — before fix:
```
1. **Prepare Project**: Create a worker script.
2. **Create config**: Add wrangler.toml.
```
Would output: `<li>**Prepare Project**: Create a worker script.</li>` (raw `**`)

## Fix

Use `marked.parseInline(item.text)` in the custom `list` renderer so each item's text is run through the inline rendering pipeline:

```typescript
const body = items
  .map(item => `<li class="leading-relaxed">${marked.parseInline(item.text)}</li>`)
  .join("");
```

Also removed the now-unused `renderer.listitem` override (it was never called since the custom `list` renderer handled items directly).

## After fix

```
1. <strong>Prepare Project</strong>: Create a worker script.
2. <strong>Create config</strong>: Add wrangler.toml.
```

All inline tokens (bold, italic, inline code) now render correctly inside list items.

## Testing

- `pnpm run build` — 0 errors, 0 warnings, 0 hints