### PR TITLE
fix: call marked.parseInline() in inline renderers so bold/italic/code actually render

### DIFF
--- a/src/components/AiPostAssistant.astro
+++ b/src/components/AiPostAssistant.astro
@@ -284,12 +284,13 @@
     };
     renderer.codespan = ({ text }) =>
       `<code class="rounded px-1 py-0.5 text-[0.8em] font-mono bg-accent/10 text-accent/90 border border-border/20">${text}</code>`;
+    // In marked v18, `text` in inline renderers is raw markdown — call parseInline() to render nested tokens
     renderer.strong = ({ text }) =>
-      `<strong class="font-semibold text-foreground/90">${text}</strong>`;
+      `<strong class="font-semibold text-foreground/90">${marked.parseInline(text)}</strong>`;
     renderer.em = ({ text }) =>
-      `<em class="italic text-foreground/80">${text}</em>`;
+      `<em class="italic text-foreground/80">${marked.parseInline(text)}</em>`;
     renderer.paragraph = ({ text }) =>
-      `<p class="mb-2 last:mb-0">${text}</p>`;
+      `<p class="mb-2 last:mb-0">${marked.parseInline(text)}</p>`;
     renderer.list = (token) => {
       const tag = (token as { ordered?: boolean }).ordered ? "ol" : "ul";
       const cls = (token as { ordered?: boolean }).ordered
@@ -310,7 +311,7 @@
         depth === 1 ? "text-base font-bold mt-3 mb-1" :
         depth === 2 ? "text-sm font-semibold mt-2 mb-1" :
         "text-sm font-medium mt-1 mb-0.5";
-      return `<h${depth} class="${cls}">${text}</h${depth}>`;
+      return `<h${depth} class="${cls}">${marked.parseInline(text)}</h${depth}>`;
     };
     marked.use({ renderer, breaks: true });
 


### PR DESCRIPTION
## Bug

In marked v18, every renderer callback receives the **raw markdown source** as `text`, not pre-rendered HTML. This means `**bold**` inside a paragraph, heading, or `strong` wrapper was never processed — the asterisks were passed through as-is and rendered as literal `**`.

**Affected renderers** (before this fix):
- `renderer.strong` — `text` = `"1. \`src/_worker.js\`"` (raw, backticks unrendered)
- `renderer.em` — `text` = raw markdown
- `renderer.paragraph` — `text` = raw markdown  
- `renderer.heading` — `text` = raw markdown

**Not affected** (correctly handled already):
- `renderer.codespan` — `text` is already the plain code string (no further inline markdown)
- `renderer.code` — `text` is the plain block code string
- `renderer.list` items — fixed in PR #23 with `marked.parseInline()`

## Fix

Call `marked.parseInline(text)` in all four affected renderers so nested inline tokens (bold inside a paragraph, inline code inside a heading, etc.) are properly rendered:

```typescript
renderer.strong = ({ text }) =>
  `<strong ...>${marked.parseInline(text)}</strong>`;
renderer.em = ({ text }) =>
  `<em ...>${marked.parseInline(text)}</em>`;
renderer.paragraph = ({ text }) =>
  `<p ...>${marked.parseInline(text)}</p>`;
renderer.heading = ({ text, depth }) =>
  `<h${depth} ...>${marked.parseInline(text)}</h${depth}>`;
```

## Result

`**1. \`src/_worker.js\`**` now renders as `<strong>1. <code>src/_worker.js</code></strong>` instead of showing raw `**` asterisks.

## Testing

- `pnpm run build` — 0 errors, 0 warnings, 0 hints