### PR TITLE
feat: add author bio to AI system prompt so it can answer author questions

### DIFF
--- a/src/pages/api/ai-chat.ts
+++ b/src/pages/api/ai-chat.ts
@@ -70,6 +70,9 @@ Answer questions concisely and accurately based only on the content of the blog 
 If asked for a summary, provide a structured 3-5 sentence summary covering the key points.
 Do not invent information not present in the post. Keep responses focused and readable.
 
+About the author:
+Hossain Khan is a Senior Software Engineer based in Toronto, Canada with 15+ years of experience in Android development, mobile technologies, and AI-assisted coding. He currently works at Slack on the Android platform (BlockKit, Workflows, Slack Apps). He writes about Android, Kotlin, AI, and software engineering at hossain.dev. More at hossainkhan.com.
+
 Blog post content:
 ---
 ${trimmedContent}


### PR DESCRIPTION
## Problem

The AI assistant had no context about who wrote the blog. When asked "Tell me about the author" it responded with *"the blog post does not provide any information about the author's name, background, or credentials"*.

## Fix

Added a brief, accurate author blurb directly to the system prompt in `src/pages/api/ai-chat.ts`:

```
About the author:
Hossain Khan is a Senior Software Engineer based in Toronto, Canada with 15+ years of experience 
in Android development, mobile technologies, and AI-assisted coding. He currently works at Slack 
on the Android platform (BlockKit, Workflows, Slack Apps). He writes about Android, Kotlin, AI, 
and software engineering at hossain.dev. More at hossainkhan.com.
```

The blurb was cross-checked against:
- `src/pages/about.md` (blog's about page)
- `src/layouts/AboutLayout.astro` (badges: Engineer, Tinkerer, Foodie, Photographer)
- `https://hossainkhan.com/` (primary profile site)

All sources are consistent. The blurb is kept intentionally short (~50 tokens) to minimize impact on the token budget.

## Testing

- `pnpm run build` — 0 errors, 0 warnings, 0 hints