### PR TITLE
feat: route AI calls through AI Gateway for rate limiting and observability

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -159,6 +159,10 @@ Set these in **Cloudflare Dashboard → Workers & Pages → hossains-dev-bytes �
 - `GITHUB_TOKEN` - GitHub Personal Access Token (with `public_repo` scope) - used by GitHubEmbed component
 - Any other runtime secrets needed by the app
 
+**Wrangler Variables** (`wrangler.jsonc` `vars` section — committed to source):
+- `AI_MODEL` - Workers AI model ID (default: `@cf/meta/llama-3.1-8b-instruct-fp8`). Change here to swap models with no code change.
+- `AI_GATEWAY_ID` - AI Gateway name (default: `hossains-dev-bytes`). Routes all AI requests through the gateway for rate limiting, caching, and observability. Configure the gateway at: **Cloudflare Dashboard → AI → AI Gateway**.
+
 **GitHub Actions** (Pre-deployment checks):
 Runs on Node 22.x and 24.x when pushing to `main`:
 - Checks ESLint rules
@@ -215,6 +219,8 @@ const greeting = "hello";
 | **Formatting conflicts** | Delete `.prettierrc.mjs` and rebuild if corrupted |
 | **GitHubEmbed shows error (403)** | Token not set in Cloudflare. Go to **Cloudflare Dashboard → Workers & Pages → hossains-dev-bytes → Settings → Environment variables** and add `GITHUB_TOKEN` |
 | **GitHubEmbed component fails locally** | Create `.env` file from `.env.example` and add your GitHub Personal Access Token |
+| **AI assistant shows "Daily AI usage limit reached"** | Rate limit on AI Gateway triggered. Wait until midnight UTC for daily reset, or raise the limit at **Cloudflare Dashboard → AI → AI Gateway → hossains-dev-bytes → Settings → Rate Limiting** |
+| **AI assistant not routing through gateway / no gateway logs** | Ensure the gateway named `hossains-dev-bytes` exists in the Cloudflare Dashboard under AI → AI Gateway. The `AI_GATEWAY_ID` var in `wrangler.jsonc` must match the gateway name exactly |
 
 ## CI/CD Pipeline
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Below is a summary of all changes and visual improvements implemented in the blo
 
 ### Recent Modifications
 
+- **Apr 11, 2026** - `2a65811`: feat: route AI calls through AI Gateway for rate limiting and observability
+  > *Added Cloudflare AI Gateway as an intermediary for all Workers AI requests. The gateway (`hossains-dev-bytes`) provides native rate limiting (configurable in the Cloudflare dashboard), response caching, and a usage analytics dashboard — with no custom quota tracking code needed. The `AI_GATEWAY_ID` var in `wrangler.jsonc` controls which gateway is used. The API endpoint detects 429 responses from the gateway and returns a user-friendly "Daily AI usage limit reached" message.*
+
 - **Apr 11, 2026** - `f48cd39`: fix: call marked.parseInline() in all inline renderers so bold/italic/code actually render
   > *Root cause: in marked v18, all renderer callbacks receive raw markdown as `text` — not pre-rendered HTML. `**bold**` inside paragraphs, headings, and `strong` wrappers was never processed. Fixed by calling `marked.parseInline(text)` in `strong`, `em`, `paragraph`, and `heading` renderers.*
 

--- a/CUSTOMIZATIONS.md
+++ b/CUSTOMIZATIONS.md
@@ -620,7 +620,7 @@ Rendered after the social links block in the hero, guarded by `SITE.introAudio.e
 **Files:**
 - `src/components/AiPostAssistant.astro` — client-side panel component
 - `src/pages/api/ai-chat.ts` — Cloudflare Workers AI API endpoint
-- `wrangler.jsonc` — AI binding and model configuration
+- `wrangler.jsonc` — AI binding, model, and gateway configuration
 
 ### Overview
 
@@ -633,9 +633,10 @@ Every blog post page includes an AI-powered assistant panel. Readers can:
 ```
 Browser (AiPostAssistant.astro)
   └─ POST /api/ai-chat  (JSON: { content, messages })
-        └─ Cloudflare Workers AI  (env.AI.run)
-              └─ @cf/meta/llama-3.1-8b-instruct-fp8
-                    └─ SSE stream → browser
+        └─ Cloudflare AI Gateway  (rate limiting, caching, observability)
+              └─ Cloudflare Workers AI  (env.AI.run)
+                    └─ @cf/meta/llama-3.1-8b-instruct-fp8
+                          └─ SSE stream → browser
 ```
 
 - **Binding:** The `AI` binding is declared in `wrangler.jsonc` under `"ai": { "binding": "AI" }`. This makes `env.AI` available inside any Worker/API route.
@@ -644,6 +645,11 @@ Browser (AiPostAssistant.astro)
   - Context window: 32,000 tokens
   - Pricing (Apr 2026): ~\$0.152 / M input tokens, ~\$0.287 / M output tokens
   - See all available models: https://developers.cloudflare.com/workers-ai/models/
+- **AI Gateway:** All requests route through the `hossains-dev-bytes` AI Gateway (configured via `AI_GATEWAY_ID` in `wrangler.jsonc`). This provides:
+  - **Rate limiting** — caps daily requests to stay within the 10,000 free neurons/day limit. Configure at: Cloudflare Dashboard → AI → AI Gateway → Settings → Rate Limiting (recommended: 150 req/day, fixed window)
+  - **Response caching** — repeated identical questions on the same post return cached responses at zero neuron cost
+  - **Observability** — token usage, latency, and error dashboards in the Cloudflare dashboard
+  - See: https://developers.cloudflare.com/ai-gateway/
 
 ### API Endpoint (`/api/ai-chat`)
 
@@ -654,7 +660,7 @@ Browser (AiPostAssistant.astro)
 | `content` | `string` | Raw post text, trimmed to `MAX_CONTENT_LENGTH` (8,000 chars) |
 | `messages` | `{role, content}[]` | Full conversation history (user + assistant turns) |
 
-The endpoint prepends a **system prompt** containing the post content so the model answers only from the article. It then calls `env.AI.run()` with `stream: true` and returns the raw `ReadableStream` as `text/event-stream` (SSE).
+The endpoint prepends a **system prompt** containing the post content so the model answers only from the article. It then calls `env.AI.run()` with `stream: true` and a `gateway` option (pointing to the AI Gateway), and returns the raw `ReadableStream` as `text/event-stream` (SSE). If the AI Gateway returns a `429` (rate limit exceeded), the endpoint returns a user-friendly error message instead of the generic 500.
 
 **Token budget:** `MAX_CONTENT_LENGTH = 8_000` chars (~2,000 tokens). Covers most posts while keeping per-request cost low. Raise or lower this constant to tune the tradeoff.
 

--- a/src/components/AiPostAssistant.astro
+++ b/src/components/AiPostAssistant.astro
@@ -346,7 +346,11 @@
 
         if (!res.ok || !res.body) {
           const errData = await res.json().catch(() => ({}));
-          throw new Error((errData as { error?: string }).error ?? `HTTP ${res.status}`);
+          const errMsg =
+            (errData as { error?: string }).error ?? `HTTP ${res.status}`;
+          // Surface the rate-limit message directly without "Error: " prefix
+          if (res.status === 429) throw new Error(errMsg);
+          throw new Error(errMsg);
         }
 
         const reader = res.body.getReader();
@@ -380,7 +384,8 @@
           }
         }
       } catch (e) {
-        showError(`Error: ${e instanceof Error ? e.message : String(e)}`);
+        const msg = e instanceof Error ? e.message : String(e);
+        showError(msg.startsWith("Daily AI") ? msg : `Error: ${msg}`);
         // Remove the empty bubble if stream failed before anything rendered
         if (!fullResponse && responseEl.parentElement) {
           responseEl.parentElement.remove();

--- a/src/pages/api/ai-chat.ts
+++ b/src/pages/api/ai-chat.ts
@@ -92,11 +92,22 @@ ${trimmedContent}
     // See available models: https://developers.cloudflare.com/workers-ai/models/
     // See pricing: https://developers.cloudflare.com/workers-ai/platform/pricing/
     const model = (env.AI_MODEL ?? "@cf/meta/llama-3.1-8b-instruct-fp8") as Parameters<typeof env.AI.run>[0];
-    const stream = await env.AI.run(model, {
-      messages: allMessages,
-      stream: true,
-      max_tokens: 1024,
-    });
+
+    // Route through AI Gateway for rate limiting, caching, and observability.
+    // Configure rate limits at: Cloudflare Dashboard > AI > AI Gateway > Settings > Rate Limiting
+    // See: https://developers.cloudflare.com/ai-gateway/providers/workersai/#workers-binding
+    const gatewayId = env.AI_GATEWAY_ID ?? "";
+    const gatewayOptions = gatewayId ? { gateway: { id: gatewayId } } : {};
+
+    const stream = await env.AI.run(
+      model,
+      {
+        messages: allMessages,
+        stream: true,
+        max_tokens: 1024,
+      },
+      gatewayOptions,
+    );
 
     return new Response(stream as ReadableStream, {
       headers: {
@@ -108,6 +119,19 @@ ${trimmedContent}
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error("[ai-chat] Workers AI error:", e);
+
+    // AI Gateway returns 429 when the rate limit is exceeded.
+    const errMsg = e instanceof Error ? e.message : String(e);
+    if (errMsg.includes("429") || errMsg.toLowerCase().includes("rate limit")) {
+      return new Response(
+        JSON.stringify({
+          error:
+            "Daily AI usage limit reached. Please try again tomorrow.",
+        }),
+        { status: 429, headers: { "content-type": "application/json" } },
+      );
+    }
+
     return new Response(JSON.stringify({ error: "AI inference failed" }), {
       status: 500,
       headers: { "content-type": "application/json" },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,6 +22,7 @@
 		// Create the gateway at: Cloudflare Dashboard > AI > AI Gateway
 		// Then enable rate limiting in: Settings > Rate Limiting (recommended: 150 req/day fixed window)
 		// See: https://developers.cloudflare.com/ai-gateway/
+		// https://developers.cloudflare.com/ai-gateway/usage/providers/workersai/#workers-binding
 		"AI_GATEWAY_ID": "hossains-dev-bytes"
 	}
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,6 +17,11 @@
 		// AI model to use for post summarization and Q&A.
 		// Change this to try a different model without redeploying code.
 		// See available models: https://developers.cloudflare.com/workers-ai/models/
-		"AI_MODEL": "@cf/meta/llama-3.1-8b-instruct-fp8"
+		"AI_MODEL": "@cf/meta/llama-3.1-8b-instruct-fp8",
+		// AI Gateway ID for rate limiting, caching, and observability.
+		// Create the gateway at: Cloudflare Dashboard > AI > AI Gateway
+		// Then enable rate limiting in: Settings > Rate Limiting (recommended: 150 req/day fixed window)
+		// See: https://developers.cloudflare.com/ai-gateway/
+		"AI_GATEWAY_ID": "hossains-dev-bytes"
 	}
 }


### PR DESCRIPTION
## Summary

Routes all Workers AI calls through **Cloudflare AI Gateway** to enable native rate limiting, response caching, and observability — no custom quota tracking code needed.

Fixes https://github.com/hossain-khan/hossains-dev-bytes/issues/26

## What Changed

### `wrangler.jsonc`
- Added `AI_GATEWAY_ID: "hossains-dev-bytes"` var — the gateway name to route requests through

### `src/pages/api/ai-chat.ts`
- Pass `{ gateway: { id: gatewayId } }` as the third argument to `env.AI.run()` so all requests flow through AI Gateway
- Detects 429 rate-limit responses from the gateway in the catch block
- Returns a user-friendly `429` response: _"Daily AI usage limit reached. Please try again tomorrow."_

### `src/components/AiPostAssistant.astro`
- 429 responses surface the message directly (without the generic `"Error: "` prefix)

## Manual Setup Required (One-Time)

Before this works in production, create the AI Gateway in the Cloudflare Dashboard:

1. Go to **Cloudflare Dashboard → AI → AI Gateway**
2. Click **Create Gateway** → name it `hossains-dev-bytes`
3. Go to **Settings → Rate Limiting → Enable**
4. Set: **150 requests / 1 day / Fixed window**
   - Rationale: 150 req × ~60 neurons/req ≈ 9,000 neurons — safely under the 10,000/day free tier

## Why AI Gateway (not custom KV)

| | AI Gateway | Custom KV |
|---|---|---|
| Rate limiting | ✅ Native, dashboard-configured | Manual read-modify-write |
| Caching | ✅ Free (identical responses cached) | Not included |
| Observability | ✅ Token usage, latency, errors | Custom logging needed |
| Code changes | ✅ 1 line | ~100 lines new utility |
| Consistency | ✅ Cloudflare-managed | Eventual (KV) |

## Neuron Math

- Model: `@cf/meta/llama-3.1-8b-instruct-fp8`
- ~60 neurons per request (8K char post + 1024 max output tokens)
- Free tier: 10,000 neurons/day ÷ 60 = **~166 requests/day**
- Rate limit set to **150/day** (10% safety buffer)
