### PR TITLE
feat: add GitHubEmbed to existing posts and update amardeshbd URLs

### DIFF
--- a/src/data/blog/android-remote-logging-to-airtable-using-timber.mdx
+++ b/src/data/blog/android-remote-logging-to-airtable-using-timber.mdx
@@ -7,6 +7,8 @@ featured: false
 draft: false
 ---
 
+import GitHubEmbed from "@/components/GitHubEmbed.astro";
+
 Have you ever needed to save your Android Logcat logs for later analysis?
 
 ---
@@ -263,7 +265,7 @@ Timber.tag("Cart").d("New item added to cart")
 
 You can take a look at the fully [implemented tree](https://github.com/hossain-khan/android-keep-alive/blob/main/app/src/main/java/dev/hossain/keepalive/log/ApiLoggingTree.kt) in the following project
 
-[**GitHub - hossain-khan/android-keep-alive: A simple app to keep alive specific apps** — _A simple app to keep alive specific apps. Has support for remote logging._](https://github.com/hossain-khan/android-keep-alive)
+<GitHubEmbed repo="hossain-khan/android-keep-alive" />
 
 Here is a screenshot of how the log looks in the Airtable
 

--- a/src/data/blog/create-your-own-mock-api-server-with-express-js-and-firebase-for-free.mdx
+++ b/src/data/blog/create-your-own-mock-api-server-with-express-js-and-firebase-for-free.mdx
@@ -7,6 +7,8 @@ featured: false
 draft: false
 ---
 
+import GitHubEmbed from "@/components/GitHubEmbed.astro";
+
 Recently I had to prepare a complete mocked server for an app I worked in the past. The reason mocking was required so that app’s different functionality can be showcased with a variation of mocked response which triggers different UI and functionality.
 
 There may be different solutions available in the market, however, since Firebase has a free tier and the Node.js-based [Express](https://expressjs.com/) web framework makes things much easier to customize based on need.
@@ -79,7 +81,7 @@ First, update **rewrites** rule of `/firebase.json` to forward all requests to F
 ]
 ```
 
-See [github-sample](https://github.com/amardeshbd/firebase-mock-api-server/blob/master/firebase.json#L17) for reference.
+See [github-sample](https://github.com/hossain-khan/firebase-mock-api-server/blob/master/firebase.json#L17) for reference.
 
 Now, update `/functions/package.json` file to include express and cors under `"dependencies"`.
 
@@ -91,7 +93,7 @@ Now, update `/functions/package.json` file to include express and cors under `"d
 }
 ```
 
-See [github-sample](https://github.com/amardeshbd/firebase-mock-api-server/blob/master/functions/package.json#L14) for reference.
+See [github-sample](https://github.com/hossain-khan/firebase-mock-api-server/blob/master/functions/package.json#L14) for reference.
 
 Once this is done, you need to update `npm` modules so that Express can be used. Use the following commands to update it.
 
@@ -107,13 +109,13 @@ Now that `app` is an Express instance, you can start defining APIs using [routin
 
 NOTE: All the APIs must be added before “exports.api = …” line.
 
-See [GitHub example](https://github.com/amardeshbd/firebase-mock-api-server/blob/master/functions/index.js) with HTTP ‘`get`’ & ‘`post`’ API with a dynamic response based on request data. The example also shows how you can load large data from JSON file, which keeps the “index.js” file clean from hard-coded data.
+See [GitHub example](https://github.com/hossain-khan/firebase-mock-api-server/blob/master/functions/index.js) with HTTP ‘`get`’ & ‘`post`’ API with a dynamic response based on request data. The example also shows how you can load large data from JSON file, which keeps the “index.js” file clean from hard-coded data.
 
 Once you are done adding APIs, you can run `**firebase deploy**` from root of the project to deploy your APIs.
 
 > NOTE: If you are getting HTTP 500 error — Your client does not have permission, then see troubleshooting section at the end of this article.
 
-Here are some example APIs that are available from the [example](https://github.com/amardeshbd/firebase-mock-api-server) GitHub project.
+Here are some example APIs that are available from the [example](https://github.com/hossain-khan/firebase-mock-api-server) GitHub project.
 
 - [https://mock-apis-server.firebaseapp.com/say/hello?name=Ryan](https://mock-apis-server.firebaseapp.com/say/hello?name=Ryan)
 - [https://mock-apis-server.firebaseapp.com/photos/29647](https://mock-apis-server.firebaseapp.com/photos/29647)
@@ -136,9 +138,7 @@ Happy mocking 😃!
 
 ---
 
-See [https://github.com/amardeshbd/firebase-mock-api-server](https://github.com/amardeshbd/firebase-mock-api-server) for more detailed example and sample APIs you can test from the browser.
-
-[**amardeshbd/firebase-mock-api-server** — _A simple mock API server using expressjs that is hosted on firebase. - amardeshbd/firebase-mock-api-server_](https://github.com/amardeshbd/firebase-mock-api-server)
+<GitHubEmbed repo="hossain-khan/firebase-mock-api-server" />
 
 ---
 

--- a/src/data/blog/dark-mode-for-medium-com-why-doesn-t-it-exist-yet.md
+++ b/src/data/blog/dark-mode-for-medium-com-why-doesn-t-it-exist-yet.md
@@ -21,7 +21,7 @@ I have a love and [hate](https://twitter.com/hossainkhan/status/1264173083885273
 
 Recently Medium has launched “**MOMENTUM** — *A Medium blog about the fight against anti-Black racism*” — a great initiative by them ✊. An interesting thing to note is the site supports dark mode. In fact, it only is in dark-mode which goes with the theme of the topic.
 
-_ps. I also built an_ [_Android app_](https://github.com/amardeshbd/android-police-brutality-incidents) _to support_ `*#BlackLivesMatter*` _cause. Currently waiting for Google to approve the app._
+_ps. I also built an_ [_Android app_](https://github.com/hossain-khan/android-police-brutality-incidents) _to support_ `*#BlackLivesMatter*` _cause. Currently waiting for Google to approve the app._
 
 If having a completely dark theme for MOMENTUM is possible, then supporting site-wide dark-mode (aka. Night Mode) should also be possible. I am hopeful that sometime soon they may publish user settings to turn on dark-mode like few other major sites (eg. YouTube, Reddit, Slack and so on).
 

--- a/src/data/blog/hackathon-creating-the-simplest-muzei-wallpaper-plugin-for-android.md
+++ b/src/data/blog/hackathon-creating-the-simplest-muzei-wallpaper-plugin-for-android.md
@@ -17,7 +17,7 @@ I have a hobby of taking a lot of pictures, and some of the pictures do turn out
 
 As an Android engineer, I was aware of [**Muzei Live Wallpaper**](https://play.google.com/store/apps/details?id=net.nurik.roman.muzei) app created by [Roman Nurik](https://medium.com/u/90c74515fd18) back in 2014. Recently I’ve seen some updates from [Ian Lake](https://medium.com/u/51a4f24f5367) who took over the project a while ago, so I decided to make a plugin for Muzei to use my pictures as wallpaper on my Android phone.
 
-> ps. If you simply want to use the plugin, see [README](https://github.com/amardeshbd/android-hk-vision-muzei-plugin/blob/master/README.md) for instruction 🤗
+> ps. If you simply want to use the plugin, see [README](https://github.com/hossain-khan/android-hk-vision-muzei-plugin/blob/master/README.md) for instruction 🤗
 
 ---
 
@@ -30,17 +30,17 @@ Essentially, I had to do 2 major tasks to create the Android plugin
 
 #### Download Image Metadata
 
-You can use any library of your choice to do that, I’ve followed the [unsplash example](https://github.com/romannurik/muzei/tree/master/example-unsplash/src/main/java/com/example/muzei/unsplash) and used Retrofit+WorkManager to download metadata and convert the images into `Artwork` objects. See [source code snapshot](https://github.com/amardeshbd/android-hk-vision-muzei-plugin/blob/master/app/src/main/java/com/hossainkhan/vision/data/HkVisionWorker.kt) from GitHub.
+You can use any library of your choice to do that, I’ve followed the [unsplash example](https://github.com/romannurik/muzei/tree/master/example-unsplash/src/main/java/com/example/muzei/unsplash) and used Retrofit+WorkManager to download metadata and convert the images into `Artwork` objects. See [source code snapshot](https://github.com/hossain-khan/android-hk-vision-muzei-plugin/blob/master/app/src/main/java/com/hossainkhan/vision/data/HkVisionWorker.kt) from GitHub.
 
 #### Expose Content Provider
 
-Based on `MuzeiArtProvider` [documentation](https://api.muzei.co/reference/com.google.android.apps.muzei.api.provider/-muzei-art-provider/index.html), I extended my `[HkVisionArtProvider](https://github.com/amardeshbd/android-hk-vision-muzei-plugin/blob/master/app/src/main/java/com/hossainkhan/vision/muzei/HkVisionArtProvider.kt)` from it and defined following provider specification in `AndroidManifest.xml`
+Based on `MuzeiArtProvider` [documentation](https://api.muzei.co/reference/com.google.android.apps.muzei.api.provider/-muzei-art-provider/index.html), I extended my `[HkVisionArtProvider](https://github.com/hossain-khan/android-hk-vision-muzei-plugin/blob/master/app/src/main/java/com/hossainkhan/vision/muzei/HkVisionArtProvider.kt)` from it and defined following provider specification in `AndroidManifest.xml`
 
 ---
 
 ![](https://cdn-images-1.medium.com/max/1200/1*Wc_NtCluWXrOokPaWsGICg.png)
 
-[Source code](https://github.com/amardeshbd/android-hk-vision-muzei-plugin/blob/master/app/src/main/AndroidManifest.xml#L15) available at the GitHub repository
+[Source code](https://github.com/hossain-khan/android-hk-vision-muzei-plugin/blob/master/app/src/main/AndroidManifest.xml#L15) available at the GitHub repository
 
 ---
 
@@ -52,4 +52,4 @@ I have released the plugin app on Google Play as a _public_ release. If you are 
 
 💻 Source code of the Android project is available at GitHub repo below:
 
-[**amardeshbd/android-hk-vision-muzei-plugin** — _Muzei Live Wallpaper app’s photo data source plugin for vision.hossainkhan.com website. _](https://github.com/amardeshbd/android-hk-vision-muzei-plugin)
+[**hossain-khan/android-hk-vision-muzei-plugin** — _Muzei Live Wallpaper app's photo data source plugin for vision.hossainkhan.com website. _](https://github.com/hossain-khan/android-hk-vision-muzei-plugin)

--- a/src/data/blog/hackathon-creating-the-simplest-muzei-wallpaper-plugin-for-android.md
+++ b/src/data/blog/hackathon-creating-the-simplest-muzei-wallpaper-plugin-for-android.md
@@ -17,7 +17,7 @@ I have a hobby of taking a lot of pictures, and some of the pictures do turn out
 
 As an Android engineer, I was aware of [**Muzei Live Wallpaper**](https://play.google.com/store/apps/details?id=net.nurik.roman.muzei) app created by [Roman Nurik](https://medium.com/u/90c74515fd18) back in 2014. Recently I’ve seen some updates from [Ian Lake](https://medium.com/u/51a4f24f5367) who took over the project a while ago, so I decided to make a plugin for Muzei to use my pictures as wallpaper on my Android phone.
 
-> ps. If you simply want to use the plugin, see [README](https://github.com/hossain-khan/android-hk-vision-muzei-plugin/blob/master/README.md) for instruction 🤗
+> ps. If you simply want to use the plugin, see [README](https://github.com/hossain-khan/android-hk-vision-muzei-plugin/blob/master/README.md) for instructions 🤗
 
 ---
 
@@ -34,7 +34,7 @@ You can use any library of your choice to do that, I’ve followed the [unsplash
 
 #### Expose Content Provider
 
-Based on `MuzeiArtProvider` [documentation](https://api.muzei.co/reference/com.google.android.apps.muzei.api.provider/-muzei-art-provider/index.html), I extended my `[HkVisionArtProvider](https://github.com/hossain-khan/android-hk-vision-muzei-plugin/blob/master/app/src/main/java/com/hossainkhan/vision/muzei/HkVisionArtProvider.kt)` from it and defined following provider specification in `AndroidManifest.xml`
+Based on `MuzeiArtProvider` [documentation](https://api.muzei.co/reference/com.google.android.apps.muzei.api.provider/-muzei-art-provider/index.html), I extended my [HkVisionArtProvider](https://github.com/hossain-khan/android-hk-vision-muzei-plugin/blob/master/app/src/main/java/com/hossainkhan/vision/muzei/HkVisionArtProvider.kt) from it and defined following provider specification in `AndroidManifest.xml`
 
 ---
 

--- a/src/data/blog/setup-android-gradle-based-firebase-app-distribution-with-github-actions-ci.md
+++ b/src/data/blog/setup-android-gradle-based-firebase-app-distribution-with-github-actions-ci.md
@@ -98,7 +98,7 @@ jobs:
 
 That’s it, you should have a working GitHub workflow that automatically sends APK to Firebase App Distribution as soon as there is a commit on `master` branch.
 
-See [pull-request I made](https://github.com/amardeshbd/android-police-brutality-incidents/pull/117/files) to add support for this in one of my side projects.
+See [pull-request I made](https://github.com/hossain-khan/android-police-brutality-incidents/pull/117/files) to add support for this in one of my side projects.
 
 If you find any issues please let me know I will try to help. Good luck 👍
 
@@ -108,4 +108,4 @@ If you find any issues please let me know I will try to help. Good luck 👍
 
 - Firebase App Distribution — [https://firebase.google.com/docs/app-distribution](https://firebase.google.com/docs/app-distribution)
 - GitHub Actions — [https://help.github.com/en/actions](https://help.github.com/en/actions)
-- Pull Request to support Firebase App Distribution — [https://github.com/amardeshbd/android-police-brutality-incidents/pull/117/files](https://github.com/amardeshbd/android-police-brutality-incidents/pull/117/files)
+- Pull Request to support Firebase App Distribution — [https://github.com/hossain-khan/android-police-brutality-incidents/pull/117/files](https://github.com/hossain-khan/android-police-brutality-incidents/pull/117/files)

--- a/src/data/blog/setup-android-gradle-based-firebase-app-distribution-with-github-actions-ci.md
+++ b/src/data/blog/setup-android-gradle-based-firebase-app-distribution-with-github-actions-ci.md
@@ -108,4 +108,4 @@ If you find any issues please let me know I will try to help. Good luck 👍
 
 - Firebase App Distribution — [https://firebase.google.com/docs/app-distribution](https://firebase.google.com/docs/app-distribution)
 - GitHub Actions — [https://help.github.com/en/actions](https://help.github.com/en/actions)
-- Pull Request to support Firebase App Distribution — [https://github.com/hossain-khan/android-police-brutality-incidents/pull/117/files](https://github.com/hossain-khan/android-police-brutality-incidents/pull/117/files)
+- Pull Request to support Firebase App Distribution - [https://github.com/hossain-khan/android-police-brutality-incidents/pull/117/files](https://github.com/hossain-khan/android-police-brutality-incidents/pull/117/files)

--- a/src/data/blog/source-code-syntax-highlighting-on-android-taking-full-control.mdx
+++ b/src/data/blog/source-code-syntax-highlighting-on-android-taking-full-control.mdx
@@ -7,6 +7,8 @@ featured: false
 draft: false
 ---
 
+import GitHubEmbed from "@/components/GitHubEmbed.astro";
+
 Android and its community has evolved a lot over past decade. Nowadays we can find open-source libraries to do almost anything — Zoomable ImageView, CameraX, RecyclerView Sticky Header, Tooltip, and many more.
 
 ![](https://cdn-images-1.medium.com/max/800/0*Ywlp-1OAf-_EgtyR)
@@ -169,7 +171,7 @@ All the example source code provided here is available in following GitHub repos
 
 If you find any issue, leave a comment here or report an issue at GitHub repository. Hope it helps somebody. ✌️
 
-[**amardeshbd/android-syntax-highlighter** — _Yet Another Android Syntax Highlighter (YAASH). Example of how to use any JavaScript library to enable syntax highlighting in your android app._](https://github.com/amardeshbd/android-syntax-highlighter)
+<GitHubEmbed repo="hossain-khan/android-syntax-highlighter" />
 
 ![](https://cdn-images-1.medium.com/max/800/1*mOgncKuhm9vj_kpE1LupSg.jpeg)
 

--- a/src/data/blog/travis-ci-script-for-your-swagger-openapi-specification.md
+++ b/src/data/blog/travis-ci-script-for-your-swagger-openapi-specification.md
@@ -9,7 +9,7 @@ draft: false
 
 Recently I have been working with swagger in a project. [Swagger 2.0](http://swagger.io/) has become an open standard and now referred to as [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification) _(OAS)_.
 
-I also love **medium.com**, so when I saw their API doc was hand written in plain text, I thought it would be good exercise to convert it to OpenAPI Specification format. The result is [https://github.com/amardeshbd/medium-api-specification](https://github.com/amardeshbd/medium-api-specification)
+I also love **medium.com**, so when I saw their API doc was hand written in plain text, I thought it would be good exercise to convert it to OpenAPI Specification format. The result is [https://github.com/hossain-khan/medium-api-specification](https://github.com/hossain-khan/medium-api-specification)
 
 Now, recently I’ve started adding [**Travis**](https://travis-ci.org/) Continuous Integration (CI) script for most of my recent projects. So, I wanted to add CI support for this OAS project.
 

--- a/src/data/blog/travis-ci-script-for-your-swagger-openapi-specification.md
+++ b/src/data/blog/travis-ci-script-for-your-swagger-openapi-specification.md
@@ -9,7 +9,7 @@ draft: false
 
 Recently I have been working with swagger in a project. [Swagger 2.0](http://swagger.io/) has become an open standard and now referred to as [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification) _(OAS)_.
 
-I also love **medium.com**, so when I saw their API doc was hand written in plain text, I thought it would be good exercise to convert it to OpenAPI Specification format. The result is [https://github.com/hossain-khan/medium-api-specification](https://github.com/hossain-khan/medium-api-specification)
+I also love **medium.com**, so when I saw their API doc was hand written in plain text, I thought it would be a good exercise to convert it to OpenAPI Specification format. The result is [https://github.com/hossain-khan/medium-api-specification](https://github.com/hossain-khan/medium-api-specification)
 
 Now, recently I’ve started adding [**Travis**](https://travis-ci.org/) Continuous Integration (CI) script for most of my recent projects. So, I wanted to add CI support for this OAS project.
 

--- a/src/data/blog/use-node-js-tools-on-github-actions-ci-workflow.md
+++ b/src/data/blog/use-node-js-tools-on-github-actions-ci-workflow.md
@@ -23,7 +23,7 @@ The concept is simple, you set up a node environment on CI machine, install requ
 
 > NOTE: Use node package manager portal at [npmjs.com](https://www.npmjs.com/) to find your node-module to run on GitHub Actions CI job.
 
-Use case #1: Use XML Validator module to validate XML. See [workflow file](https://github.com/amardeshbd/android-hk-vision-muzei-plugin/blob/master/.github/workflows/android.yml).
+Use case #1: Use XML Validator module to validate XML. See [workflow file](https://github.com/hossain-khan/android-hk-vision-muzei-plugin/blob/master/.github/workflows/android.yml).
 
 ```yaml
 - name: Setup NodeJS

--- a/src/data/blog/using-ai-to-build-modern-android-apps-are-we-there-yet.mdx
+++ b/src/data/blog/using-ai-to-build-modern-android-apps-are-we-there-yet.mdx
@@ -7,6 +7,8 @@ featured: false
 draft: false
 ---
 
+import GitHubEmbed from "@/components/GitHubEmbed.astro";
+
 ![](https://cdn-images-1.medium.com/max/1200/1*cq6Pf1hoCaGQ7KRD6nc_QA.jpeg)
 
 Building is more fun with AI 🤖
@@ -62,6 +64,6 @@ Along the way building the app, I got to 🧑‍💻 exercise my knowledge, lear
 
 Here is the app that is available on GitHub
 
-[**GitHub - hossain-khan/android-weather-alert: A simple app to provide configured weather alert so…** — _A simple app to provide configured weather alert so that you are ready for next hour or day! _](https://github.com/hossain-khan/android-weather-alert)
+<GitHubEmbed repo="hossain-khan/android-weather-alert" />
 
 It’s also available on [Google Play](https://play.google.com/store/apps/details?id=dev.hossain.weatheralert&pcampaignid=web_share), if the use-case mentioned talks to you :-)

--- a/src/data/blog/using-sqldelight-2-0-with-postgresql-for-jvm.mdx
+++ b/src/data/blog/using-sqldelight-2-0-with-postgresql-for-jvm.mdx
@@ -7,6 +7,8 @@ featured: false
 draft: false
 ---
 
+import GitHubEmbed from "@/components/GitHubEmbed.astro";
+
 Recently I wanted to do some experiments with saving JSON data into a database and found out that PostgreSQL supports JSON as a data type.
 
 I also wanted to use the fantastic SQLDelight library that creates type-safe models and queries for any database (it’s also multi-platform supported).
@@ -82,7 +84,7 @@ The full snippet is available [here](https://github.com/hossain-khan/SQLDelight-
 
 See the GitHub project for a complete example with gradle dependencies and SQLDelight configuration needed to make it work.
 
-[**GitHub - hossain-khan/SQLDelight-PostgreSQL-JVM-sample: A sample project exercising PostgreSQL with SQLDelight** — _A sample project exercising PostgreSQL with SQLDelight 2.0 - GitHub - hossain-khan/SQLDelight-PostgreSQL-JVM-sample_](https://github.com/hossain-khan/SQLDelight-PostgreSQL-JVM-sample)
+<GitHubEmbed repo="hossain-khan/SQLDelight-PostgreSQL-JVM-sample" />
 
 ---
 

--- a/src/data/blog/vibe-coding-to-blind-coding.mdx
+++ b/src/data/blog/vibe-coding-to-blind-coding.mdx
@@ -7,6 +7,8 @@ featured: false
 draft: false
 ---
 
+import GitHubEmbed from "@/components/GitHubEmbed.astro";
+
 > **TL;DR:** I let AI write a JSON5 parser for me using just test cases and vibes. No deep knowledge, just TDD and Agentic AIs. Shockingly, it worked!
 
 ---
@@ -59,7 +61,7 @@ If you are interested to look under the hood, take a look into the `lib` module 
 
 ![](https://cdn-images-1.medium.com/max/800/1*lYdRctfsDRysPfYYO2pzcw.png)
 
-[**GitHub - hossain-khan/json5-kotlin: JSON5 implementation for Kotlin/JVM** — _JSON5 implementation for Kotlin/JVM. Built by Coding AI Agents._](https://github.com/hossain-khan/json5-kotlin)
+<GitHubEmbed repo="hossain-khan/json5-kotlin" />
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces plain Medium-style GitHub repo links with the new `GitHubEmbed` component across existing blog posts, and updates stale `amardeshbd` GitHub URLs to `hossain-khan` where the repos have been transferred.

## Changes

**6 posts converted from `.md` → `.mdx` with `GitHubEmbed` added:**

| Post | Repo embedded |
|---|---|
| `android-remote-logging-to-airtable-using-timber` | `hossain-khan/android-keep-alive` |
| `using-sqldelight-2-0-with-postgresql-for-jvm` | `hossain-khan/SQLDelight-PostgreSQL-JVM-sample` |
| `vibe-coding-to-blind-coding` | `hossain-khan/json5-kotlin` |
| `source-code-syntax-highlighting-on-android-taking-full-control` | `hossain-khan/android-syntax-highlighter` |
| `create-your-own-mock-api-server-with-express-js-and-firebase-for-free` | `hossain-khan/firebase-mock-api-server` |
| `using-ai-to-build-modern-android-apps-are-we-there-yet` | `hossain-khan/android-weather-alert` |

**`amardeshbd` → `hossain-khan` URL updates (repos verified to exist):**
- `firebase-mock-api-server` - inline links in mock API post
- `android-syntax-highlighter` - GitHubEmbed repo slug
- `android-hk-vision-muzei-plugin` - links in muzei + node.js tools posts
- `medium-api-specification` - link in Travis CI post
- `android-police-brutality-incidents` - links across 2 posts

**Left unchanged** (repos don't exist under `hossain-khan`):
- `amardeshbd/hossainkhan.com`
- `amardeshbd/vision.hossainkhan.com`
- `gist.github.com/amardeshbd/...`