### PR TITLE
chore: update Google Analytics tag placement to top of head

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -61,6 +61,20 @@ const showGrain = SITE.backdropEffects.grain;
   class={`${scrollSmooth ? "scroll-smooth" : ""}`}
 >
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-LLPDSXLW0V"
+      is:inline></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-LLPDSXLW0V");
+    </script>
+
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -180,16 +194,6 @@ const showGrain = SITE.backdropEffects.grain;
       })();
     </script>
 
-    <!-- Global site tag (gtag.js) - Google Analytics 4 -->
-    <script is:inline async src="https://www.googletagmanager.com/gtag/js?id=G-LLPDSXLW0V"></script>
-    <script is:inline>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(...args) {
-        dataLayer.push(...args);
-      }
-      gtag('js', new Date());
-      gtag('config', 'G-LLPDSXLW0V');
-    </script>
   </head>
   <body>
     <!-- Global decorative backdrop (grid, glow, cursor glow, noise) -->

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -69,6 +69,7 @@ const showGrain = SITE.backdropEffects.grain;
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
+        // eslint-disable-next-line prefer-rest-params
         dataLayer.push(arguments);
       }
       gtag("js", new Date());


### PR DESCRIPTION
## Summary

Moves the Google Analytics (gtag.js) tag to the recommended position - immediately after the opening `<head>` tag - and removes the old duplicate tag that was near the bottom of `<head>`.

## Changes

- Removed old GA tag (was placed just before `</head>`)
- Added updated GA tag at the very top of `<head>` per Google's recommendation

## Why top of `<head>`?

Google recommends placing the tag "immediately after the `<head>` element" so the analytics script request is fired as early as possible. Since the script uses `async`, it won't block rendering either way, but earlier placement ensures more page view events are captured (e.g. from users who leave before the page fully loads).