### PR TITLE
chore: remove Google Analytics tag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -61,21 +61,6 @@ const showGrain = SITE.backdropEffects.grain;
   class={`${scrollSmooth ? "scroll-smooth" : ""}`}
 >
   <head>
-    <!-- Google tag (gtag.js) -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-LLPDSXLW0V"
-      is:inline></script>
-    <script is:inline>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        // eslint-disable-next-line prefer-rest-params
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-      gtag("config", "G-LLPDSXLW0V");
-    </script>
-
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />


### PR DESCRIPTION
Removes the Google Analytics (gtag.js) tag from `Layout.astro`.

Plan to replace with Cloudflare Web Analytics - which is already part of the Cloudflare dashboard, free, cookie-free, and privacy-friendly. The new snippet can be added once the token is obtained from the dashboard.