### PR TITLE
feat: add blog post - Syntax Highlighting on Android with Shiki and Compose

### DIFF
--- a/src/data/blog/source-code-syntax-highlighting-on-android-taking-full-control.mdx
+++ b/src/data/blog/source-code-syntax-highlighting-on-android-taking-full-control.mdx
@@ -2,7 +2,7 @@
 title: Source code syntax highlighting on Android — Taking full control
 description: Tips on how to take full control and create your own custom-view to add syntax highlighting support in your Android app.
 pubDatetime: 2020-07-18T22:13:00.452Z
-tags: ["android", "ui", "syntax"]
+tags: ["android", "ui", "syntax-highlighting"]
 featured: false
 draft: false
 ---

--- a/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
@@ -15,7 +15,7 @@ That curiosity led me down a rabbit hole involving [Shiki](https://shiki.style/)
 
 ## why Shiki?
 
-If you haven't come across Shiki before, it's the syntax highlighter used by VS Code and a lot of modern web tooling. It uses TextMate grammars - the same grammar files that power VS Code's language support - which means the highlighting quality is genuinely excellent. Colors match what you'd see in your editor.
+If you haven't come across Shiki before, it's a syntax highlighter based on TextMate grammars and themes - the same engine that powers VS Code's syntax highlighting. They're not the same thing, but they share the same underlying approach, which means the output quality is genuinely excellent. Colors match what you'd see in your editor.
 
 The other thing I liked is that it supports dual-theme responses out of the box. You can ask it to tokenize code once and get back both dark and light colors for every token in a single response. That's perfect for Android apps that respect the system dark/light mode.
 
@@ -145,27 +145,6 @@ The demo app shows API latency, line count, and character count alongside the hi
 The WebView approach from 2020 still works - and if you need to support older Views-based layouts, it's still a reasonable option. But I found the Compose + token service approach noticeably cleaner in practice. There's no WebView overhead, rendering is pure Compose, and since the result is just an `AnnotatedString` it behaves like any other text - you can select it, layer more spans on top, put it inside a `LazyColumn`, whatever. Dark and light theme support also falls out naturally from the dual-theme API call, with no extra logic on the Android side.
 
 The honest tradeoff is the network dependency. Highlighting requires a server round-trip, so it adds latency and won't work offline without the plain-text fallback. For most use cases - documentation viewers, code snippet displays, learning apps - that's fine. For a full code editor where you need instant feedback, you'd want something that runs on-device.
-
-## running your own instance
-
-I went with Cloudflare Workers for hosting since the free tier is generous and the cold start is fast thanks to the pre-compiled JS engine. But if you'd rather run it on your own server or on Heroku, both work fine too.
-
-On Cloudflare Workers:
-
-```bash
-npm install
-npm run deploy
-```
-
-On Node.js (Heroku or any server):
-
-```bash
-npm install
-npm run build
-PORT=3000 npm start
-```
-
-The service supports 23 languages (`kotlin`, `java`, `python`, `javascript`, `typescript`, `swift`, `go`, `rust`, and more) and 5 themes (`github-dark`, `github-light`, `one-dark-pro`, `dracula`, `min-light`).
 
 ---
 

--- a/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
@@ -35,7 +35,7 @@ The API has three highlight endpoints:
 - `POST /highlight/dual` - dark + light theme in one call, returns `text` + `darkColor` + `lightColor` per token
 - `POST /highlight/semantic` - returns token types (`keyword`, `function`, `string`, etc.) instead of colors, for when you want to manage the palette yourself
 
-I hosted the service at `https://syntax-highlight.gohk.xyz`. It's on Cloudflare's free tier, so latency is low and there's no cost to keep it running.
+I hosted the service at `https://syntax-highlight.gohk.xyz/docs`. It's on Cloudflare's free tier, so latency is low and there's no cost to keep it running.
 
 ## the Android side
 
@@ -63,8 +63,7 @@ private fun buildAnnotatedStringFromDualResponse(
 private fun parseHexColor(hex: String): Color {
     val clean = hex.trimStart('#')
     return when (clean.length) {
-        6 -> Color(android.graphics.Color.parseColor("#$clean"))
-        8 -> Color(android.graphics.Color.parseColor("#$clean"))
+        6, 8 -> Color(android.graphics.Color.parseColor("#$clean"))
         else -> Color.Unspecified
     }
 }
@@ -76,15 +75,8 @@ Then rendering it is just:
 Text(
     text = annotated,
     style = MaterialTheme.typography.bodySmall.copy(
-        fontFamily = FontFamily.Monospace,
-        fontSize = 13.sp,
-    ),
-    modifier = Modifier
-        .fillMaxSize()
-        .background(bgColor)
-        .horizontalScroll(rememberScrollState())
-        .verticalScroll(rememberScrollState())
-        .padding(12.dp),
+        fontFamily = FontFamily.Monospace
+    )
 )
 ```
 

--- a/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
@@ -1,0 +1,178 @@
+---
+title: "Syntax Highlighting on Android - Bringing Shiki Engine to Compose"
+pubDatetime: 2026-04-19T12:00:00Z
+description: "How I brought VS Code-quality syntax highlighting to Jetpack Compose by running Shiki server-side and returning colored tokens to the app - no WebView needed."
+tags: ["android", "jetpack-compose", "syntax-highlighting", "shiki", "ui"]
+featured: false
+draft: false
+---
+
+import GitHubEmbed from "@/components/GitHubEmbed.astro";
+
+One weekend I started wondering what syntax highlighting in Jetpack Compose would look like if I built it from scratch today - no `WebView`, no HTML template strings. I'd done the `WebView` + PrismJS approach [back in 2020](/posts/source-code-syntax-highlighting-on-android-taking-full-control) and it worked, but it always felt a bit awkward to embed a browser engine just to display colored text. Now that Compose is the default UI toolkit, I wanted something that fit in naturally.
+
+That curiosity led me down a rabbit hole involving [Shiki](https://shiki.style/), WebAssembly limitations, Cloudflare Workers, and a small microservice I ended up building to glue it all together. Here's how it went.
+
+## why Shiki?
+
+If you haven't come across Shiki before, it's the syntax highlighter used by VS Code and a lot of modern web tooling. It uses TextMate grammars - the same grammar files that power VS Code's language support - which means the highlighting quality is genuinely excellent. Colors match what you'd see in your editor.
+
+The other thing I liked is that it supports dual-theme responses out of the box. You can ask it to tokenize code once and get back both dark and light colors for every token in a single response. That's perfect for Android apps that respect the system dark/light mode.
+
+The catch? Shiki relies on Oniguruma, a regex engine that gets compiled to WebAssembly at runtime. WebAssembly on Android isn't something you can just drop into an app - and there's no native Android port of Shiki. So running it directly on-device is off the table for now.
+
+## the server-side workaround
+
+The idea I landed on is pretty simple: if Shiki can't run on Android, run it somewhere else and just send the result to the app.
+
+I built a small microservice - [Shiki Token Service](https://github.com/hossain-khan/shiki-token-service) - that takes source code and returns the highlighted tokens as JSON. The app never does any parsing itself; it just receives a list of tokens, each with its text and color, and renders them.
+
+The service is built with [Hono](https://hono.dev/) and runs on Cloudflare Workers. One interesting wrinkle: Cloudflare Workers also blocks WebAssembly instantiation, so I couldn't use Shiki's default WASM engine there either. The fix was to use Shiki's pre-compiled JavaScript regex engine (`@shikijs/langs-precompiled`), which transpiles all the grammar patterns at build time. No WASM needed, works everywhere, and cold starts are fast.
+
+The API has three highlight endpoints:
+
+- `POST /highlight` - single theme, returns `text` + `color` per token
+- `POST /highlight/dual` - dark + light theme in one call, returns `text` + `darkColor` + `lightColor` per token
+- `POST /highlight/semantic` - returns token types (`keyword`, `function`, `string`, etc.) instead of colors, for when you want to manage the palette yourself
+
+I hosted the service at `https://syntax-highlight.gohk.xyz`. It's on Cloudflare's free tier, so latency is low and there's no cost to keep it running.
+
+## the Android side
+
+The Compose implementation turns out to be pretty clean. The `/highlight/dual` endpoint returns a 2D array of tokens (lines of tokens), and each token carries a `text`, `darkColor`, and `lightColor`. From there it's just building a Compose `AnnotatedString`:
+
+```kotlin
+fun buildHighlightedString(
+    tokens: List<List<DualToken>>,
+    isDarkTheme: Boolean
+): AnnotatedString = buildAnnotatedString {
+    tokens.forEachIndexed { lineIndex, line ->
+        line.forEach { token ->
+            val color = if (isDarkTheme) token.darkColor else token.lightColor
+            withStyle(SpanStyle(color = Color(android.graphics.Color.parseColor(color)))) {
+                append(token.text)
+            }
+        }
+        if (lineIndex < tokens.lastIndex) append("\n")
+    }
+}
+```
+
+Then rendering it is just:
+
+```kotlin
+Text(
+    text = highlightedCode,
+    fontFamily = FontFamily.Monospace,
+    fontSize = 13.sp,
+    modifier = Modifier
+        .horizontalScroll(rememberScrollState())
+        .padding(16.dp)
+)
+```
+
+No `WebView`, no JavaScript bridge, no HTML template string. Just an `AnnotatedString` in a `Text` composable. I was pleasantly surprised by how little code this ended up being.
+
+> 💡 The dual-theme endpoint is worth using even if your app only supports one theme right now. If you ever add dark mode support later, you already have both colors sitting in the response.
+
+## the Kotlin SDK
+
+Rather than calling the REST API directly with Retrofit or Ktor, there's an Android SDK available via JitPack that wraps everything up nicely.
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        maven("https://jitpack.io")
+    }
+}
+
+// build.gradle.kts
+dependencies {
+    implementation("com.github.hossain-khan.shiki-token-service:sdk-android:sdk-1.0.5")
+}
+```
+
+Usage is straightforward - all the client methods are `suspend` functions and return `kotlin.Result<T>`:
+
+```kotlin
+val client = ShikiClient(baseUrl = "https://syntax-highlight.gohk.xyz")
+
+val result = client.highlightDual(
+    HighlightDualRequest(
+        code = sourceCode,
+        language = Language.KOTLIN
+    )
+)
+
+result.onSuccess { response ->
+    // response.tokens is List<List<DualToken>>
+    val annotated = buildHighlightedString(response.tokens, isDarkTheme)
+    // update your UI state
+}
+
+result.onFailure { error ->
+    // show plain text fallback
+}
+
+client.close()
+```
+
+The SDK uses Ktor with OkHttp under the hood on Android, and `kotlinx.serialization` for JSON. It's a Kotlin Multiplatform module too, so if you have a JVM or KMP project it works there as well.
+
+## plain text fallback
+
+One thing worth adding in your implementation is a plain-text fallback. If the device is offline or the service is unavailable, you still want to show the code - just without colors. Since you're already holding the raw source string, this is easy:
+
+```kotlin
+when (uiState) {
+    is UiState.Highlighted -> Text(
+        text = uiState.annotatedString,
+        fontFamily = FontFamily.Monospace
+    )
+    is UiState.Fallback -> Text(
+        text = uiState.rawCode,
+        fontFamily = FontFamily.Monospace,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+}
+```
+
+The demo app shows API latency, line count, and character count alongside the highlighted output - handy for getting a feel for how the service performs on real devices.
+
+## compared to the old approach
+
+The WebView approach from 2020 still works - and if you need to support older Views-based layouts, it's still a reasonable option. But I found the Compose + token service approach noticeably cleaner in practice. There's no WebView overhead, rendering is pure Compose, and since the result is just an `AnnotatedString` it behaves like any other text - you can select it, layer more spans on top, put it inside a `LazyColumn`, whatever. Dark and light theme support also falls out naturally from the dual-theme API call, with no extra logic on the Android side.
+
+The honest tradeoff is the network dependency. Highlighting requires a server round-trip, so it adds latency and won't work offline without the plain-text fallback. For most use cases - documentation viewers, code snippet displays, learning apps - that's fine. For a full code editor where you need instant feedback, you'd want something that runs on-device.
+
+## running your own instance
+
+I went with Cloudflare Workers for hosting since the free tier is generous and the cold start is fast thanks to the pre-compiled JS engine. But if you'd rather run it on your own server or on Heroku, both work fine too.
+
+On Cloudflare Workers:
+
+```bash
+npm install
+npm run deploy
+```
+
+On Node.js (Heroku or any server):
+
+```bash
+npm install
+npm run build
+PORT=3000 npm start
+```
+
+The service supports 23 languages (`kotlin`, `java`, `python`, `javascript`, `typescript`, `swift`, `go`, `rust`, and more) and 5 themes (`github-dark`, `github-light`, `one-dark-pro`, `dracula`, `min-light`).
+
+---
+
+Both projects are available on GitHub. The token service repo also has a KMP SDK in the `sdk/` directory if you want to dig into how it's structured.
+
+<GitHubEmbed repo="hossain-khan/shiki-token-service" />
+
+<GitHubEmbed repo="hossain-khan/android-syntax-highlighter-compose" />
+
+If something's not working or you run into issues, drop a comment or open a GitHub issue. Hope it helps somebody. ✌️

--- a/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
@@ -39,21 +39,33 @@ I hosted the service at `https://syntax-highlight.gohk.xyz`. It's on Cloudflare'
 
 ## the Android side
 
-The Compose implementation turns out to be pretty clean. The `/highlight/dual` endpoint returns a 2D array of tokens (lines of tokens), and each token carries a `text`, `darkColor`, and `lightColor`. From there it's just building a Compose `AnnotatedString`:
+The Compose implementation turns out to be pretty clean. The `/highlight/dual` endpoint returns a `HighlightDualResponse` containing a 2D array of tokens (lines of tokens), and each token carries a `darkColor` and `lightColor` hex string. From there it's just building a Compose `AnnotatedString` using a `parseHexColor` helper:
 
 ```kotlin
-fun buildHighlightedString(
-    tokens: List<List<DualToken>>,
-    isDarkTheme: Boolean
+private fun buildAnnotatedStringFromDualResponse(
+    response: HighlightDualResponse,
+    isDark: Boolean,
 ): AnnotatedString = buildAnnotatedString {
-    tokens.forEachIndexed { lineIndex, line ->
+    response.tokens.forEachIndexed { lineIndex, line ->
         line.forEach { token ->
-            val color = if (isDarkTheme) token.darkColor else token.lightColor
-            withStyle(SpanStyle(color = Color(android.graphics.Color.parseColor(color)))) {
+            val hex = if (isDark) token.darkColor else token.lightColor
+            val color = parseHexColor(hex)
+            withStyle(SpanStyle(color = color)) {
                 append(token.text)
             }
         }
-        if (lineIndex < tokens.lastIndex) append("\n")
+        if (lineIndex < response.tokens.lastIndex) {
+            append("\n")
+        }
+    }
+}
+
+private fun parseHexColor(hex: String): Color {
+    val clean = hex.trimStart('#')
+    return when (clean.length) {
+        6 -> Color(android.graphics.Color.parseColor("#$clean"))
+        8 -> Color(android.graphics.Color.parseColor("#$clean"))
+        else -> Color.Unspecified
     }
 }
 ```
@@ -62,22 +74,27 @@ Then rendering it is just:
 
 ```kotlin
 Text(
-    text = highlightedCode,
-    fontFamily = FontFamily.Monospace,
-    fontSize = 13.sp,
+    text = annotated,
+    style = MaterialTheme.typography.bodySmall.copy(
+        fontFamily = FontFamily.Monospace,
+        fontSize = 13.sp,
+    ),
     modifier = Modifier
+        .fillMaxSize()
+        .background(bgColor)
         .horizontalScroll(rememberScrollState())
-        .padding(16.dp)
+        .verticalScroll(rememberScrollState())
+        .padding(12.dp),
 )
 ```
 
-No `WebView`, no JavaScript bridge, no HTML template string. Just an `AnnotatedString` in a `Text` composable. I was pleasantly surprised by how little code this ended up being.
+No `WebView`, no JavaScript bridge, no HTML template string. Just an `AnnotatedString` in a `Text` composable - with a background color approximated from the theme. I was pleasantly surprised by how little code this ended up being.
 
 > 💡 The dual-theme endpoint is worth using even if your app only supports one theme right now. If you ever add dark mode support later, you already have both colors sitting in the response.
 
 ## the Kotlin SDK
 
-Rather than calling the REST API directly with Retrofit or Ktor, there's an Android SDK available via JitPack that wraps everything up nicely.
+Rather than calling the REST API directly with Retrofit or Ktor, there's an Android SDK available via JitPack. In the repo, `ShikiRepositoryImpl` wraps the `ShikiClient` and exposes a single `highlightDual` suspend function:
 
 ```kotlin
 // settings.gradle.kts
@@ -96,45 +113,75 @@ dependencies {
 Usage is straightforward - all the client methods are `suspend` functions and return `kotlin.Result<T>`:
 
 ```kotlin
-val client = ShikiClient(baseUrl = "https://syntax-highlight.gohk.xyz")
+private val client = ShikiClient(baseUrl = "https://syntax-highlight.gohk.xyz")
 
-val result = client.highlightDual(
-    HighlightDualRequest(
-        code = sourceCode,
-        language = Language.KOTLIN
+suspend fun highlightDual(
+    code: String,
+    language: String,
+    darkTheme: String,
+    lightTheme: String,
+): Result<HighlightDualResponse> =
+    client.highlightDual(
+        HighlightDualRequest(
+            code = code,
+            language = language,
+            darkTheme = darkTheme,
+            lightTheme = lightTheme,
+        ),
     )
-)
-
-result.onSuccess { response ->
-    // response.tokens is List<List<DualToken>>
-    val annotated = buildHighlightedString(response.tokens, isDarkTheme)
-    // update your UI state
-}
-
-result.onFailure { error ->
-    // show plain text fallback
-}
-
-client.close()
 ```
 
-The SDK uses Ktor with OkHttp under the hood on Android, and `kotlinx.serialization` for JSON. It's a Kotlin Multiplatform module too, so if you have a JVM or KMP project it works there as well.
+And calling it from the presenter:
+
+```kotlin
+shikiRepository
+    .highlightDual(
+        code = selectedSample.code,
+        language = selectedSample.language,
+        darkTheme = selectedThemePair.dark,
+        lightTheme = selectedThemePair.light,
+    ).onSuccess { response ->
+        // response is HighlightDualResponse
+        // pass to UI state, build AnnotatedString on the UI side
+    }.onFailure { errorMessage = it.message ?: "Unknown error" }
+```
+
+The SDK uses Ktor with OkHttp under the hood on Android, and `kotlinx.serialization` for JSON. It's a Kotlin Multiplatform module, so it works in JVM projects too.
 
 ## plain text fallback
 
-One thing worth adding in your implementation is a plain-text fallback. If the device is offline or the service is unavailable, you still want to show the code - just without colors. Since you're already holding the raw source string, this is easy:
+One thing worth having in your implementation is a plain-text fallback for when the device is offline or the service is unavailable. In the demo app this is handled by the `Error` state - it falls back to showing the raw code using the same `Text` composable but without any `AnnotatedString` coloring:
 
 ```kotlin
-when (uiState) {
-    is UiState.Highlighted -> Text(
-        text = uiState.annotatedString,
-        fontFamily = FontFamily.Monospace
-    )
-    is UiState.Fallback -> Text(
-        text = uiState.rawCode,
-        fontFamily = FontFamily.Monospace,
-        color = MaterialTheme.colorScheme.onSurface
-    )
+when (state) {
+    is State.Success -> {
+        val isDark = isSystemInDarkTheme()
+        val annotated = buildAnnotatedStringFromDualResponse(state.response, isDark)
+        Text(
+            text = annotated,
+            style = MaterialTheme.typography.bodySmall.copy(
+                fontFamily = FontFamily.Monospace,
+                fontSize = 13.sp,
+            ),
+            modifier = Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(12.dp),
+        )
+    }
+    is State.Error -> {
+        // plain text fallback when highlighting is unavailable
+        Text(
+            text = state.selectedSample.code,
+            style = MaterialTheme.typography.bodySmall.copy(
+                fontFamily = FontFamily.Monospace,
+                fontSize = 13.sp,
+            ),
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .horizontalScroll(rememberScrollState())
+                .padding(12.dp),
+        )
+    }
 }
 ```
 

--- a/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
@@ -152,12 +152,8 @@ when (state) {
         Text(
             text = annotated,
             style = MaterialTheme.typography.bodySmall.copy(
-                fontFamily = FontFamily.Monospace,
-                fontSize = 13.sp,
-            ),
-            modifier = Modifier
-                .horizontalScroll(rememberScrollState())
-                .padding(12.dp),
+                fontFamily = FontFamily.Monospace
+            )
         )
     }
     is State.Error -> {
@@ -165,13 +161,9 @@ when (state) {
         Text(
             text = state.selectedSample.code,
             style = MaterialTheme.typography.bodySmall.copy(
-                fontFamily = FontFamily.Monospace,
-                fontSize = 13.sp,
+                fontFamily = FontFamily.Monospace
             ),
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.surfaceVariant)
-                .horizontalScroll(rememberScrollState())
-                .padding(12.dp),
+            modifier = Modifier.background(MaterialTheme.colorScheme.surfaceVariant),
         )
     }
 }


### PR DESCRIPTION
## Summary

Adds a new blog post: **"Syntax Highlighting on Android - Bringing Shiki Engine to Compose"**

The post covers a server-driven approach to syntax highlighting in Jetpack Compose using [Shiki](https://shiki.style/) - no WebView required. It's a follow-up to the 2020 WebView + PrismJS post.

## What the post covers

- Why Shiki was chosen (TextMate grammars, same engine as VS Code, dual-theme support)
- Why Shiki can't run on Android directly (Oniguruma/WASM limitation)
- The [Shiki Token Service](https://github.com/hossain-khan/shiki-token-service) microservice built on Hono + Cloudflare Workers with pre-compiled JS regex engine
- Building a Compose `AnnotatedString` from tokenized JSON responses
- The Kotlin Multiplatform SDK via JitPack (`sdk-android:sdk-1.0.5`)
- Plain-text fallback for offline/error states
- Comparison to the old WebView approach

## Files changed

- `src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx` - new blog post
- `src/data/blog/source-code-syntax-highlighting-on-android-taking-full-control.mdx` - updated tag to `syntax-highlighting`

## Related repos

- https://github.com/hossain-khan/shiki-token-service
- https://github.com/hossain-khan/android-syntax-highlighter-compose