### PR TITLE
feat: add reading time chip to post header

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,6 +9,7 @@ import sitemap from "@astrojs/sitemap";
 
 import remarkToc from "remark-toc";
 import remarkCollapse from "remark-collapse";
+import { remarkReadingTime } from "./src/utils/remark-reading-time";
 
 // https://shiki.style/
 import {
@@ -37,7 +38,7 @@ export default defineConfig({
   ],
 
   markdown: {
-    remarkPlugins: [remarkToc, [remarkCollapse, { test: "Table of contents" }]],
+    remarkPlugins: [remarkReadingTime, remarkToc, [remarkCollapse, { test: "Table of contents" }]],
     shikiConfig: {
       // For more themes, visit https://shiki.style/themes
       themes: { light: "min-light", dark: "github-dark-default" },

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -34,7 +34,8 @@ const {
   hideEditPost,
 } = post.data;
 
-const { Content } = await render(post);
+const { Content, remarkPluginFrontmatter } = await render(post);
+const readingTime = (remarkPluginFrontmatter?.readingTime as string | undefined) ?? "";
 
 let ogImageUrl: string | undefined;
 
@@ -165,6 +166,27 @@ const nextPost =
               class="opacity-70 [&>svg]:hidden"
             />
           </div>
+
+          <!-- Reading time chip -->
+          {readingTime && (
+            <div
+              class="inline-flex items-center gap-1.5 rounded-lg border border-border/25 bg-muted/10 px-2.5 py-1 backdrop-blur-sm"
+            >
+              <svg
+                class="size-3.5 text-accent/70"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="12" cy="12" r="10"></circle>
+                <polyline points="12 6 12 12 16 14"></polyline>
+              </svg>
+              <span class="text-sm opacity-70">{readingTime}</span>
+            </div>
+          )}
 
           <!-- TL;DR AI Summary shortcut -->
           <a

--- a/src/utils/remark-reading-time.ts
+++ b/src/utils/remark-reading-time.ts
@@ -1,0 +1,49 @@
+// Average adult reading speed (words per minute)
+const WORDS_PER_MINUTE = 200;
+
+type AstNode = {
+  type: string;
+  value?: string;
+  children?: AstNode[];
+};
+
+type AstroVFile = {
+  data: {
+    astro?: {
+      frontmatter?: Record<string, unknown>;
+    };
+  };
+};
+
+/**
+ * Remark plugin that injects a `readingTime` string (e.g. "4 min read")
+ * into `file.data.astro.frontmatter` so it can be accessed via
+ * `remarkPluginFrontmatter.readingTime` after calling `render(post)`.
+ *
+ * No external dependencies — counts words by walking the plain text of
+ * all Literal nodes (text, inlineCode, code) in the mdast.
+ */
+export function remarkReadingTime() {
+  return function (tree: AstNode, file: AstroVFile) {
+    const text = extractText(tree);
+    const wordCount = text.split(/\s+/).filter(Boolean).length;
+    const minutes = Math.ceil(wordCount / WORDS_PER_MINUTE);
+    const readingTime = `${minutes} min read`;
+
+    // Astro exposes file.data.astro.frontmatter for remark plugin frontmatter injection
+    if (!file.data.astro) file.data.astro = {};
+    if (!file.data.astro.frontmatter) file.data.astro.frontmatter = {};
+    file.data.astro.frontmatter.readingTime = readingTime;
+  };
+}
+
+/** Walk an mdast tree and collect all plain-text content. */
+function extractText(node: AstNode): string {
+  if (typeof node.value === "string") {
+    return node.value;
+  }
+  if (Array.isArray(node.children)) {
+    return node.children.map(child => extractText(child)).join(" ");
+  }
+  return "";
+}


### PR DESCRIPTION
## What's in this PR

### Reading time chip
Adds a "N min read" chip to the post header metadata row (alongside author and date), calculated at build time via a custom remark plugin.

**How it works:**
- New `src/utils/remark-reading-time.ts` — a zero-dependency remark plugin that walks the mdast tree, counts words across all text/code nodes, and injects `readingTime` into `file.data.astro.frontmatter`
- Plugin added to `astro.config.ts` `remarkPlugins` array
- `PostDetails.astro` reads `remarkPluginFrontmatter.readingTime` from `render(post)` and renders it as a clock-icon chip in the header metadata row

### Copy button on code blocks
Already existed — `attachCopyButtons()` in `PostDetails.astro` was fully implemented. No changes needed.

## Testing
- Build passes clean (`pnpm run build`)
- Reading time chip shows on all post pages
