### PR TITLE
feat: add remark-github-alerts support with styled callouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Below is a summary of all changes and visual improvements implemented in the blo
 
 ### Recent Modifications
 
+- **Apr 26, 2026** - `44cf8b1`: feat: add remark-github-alerts support with styled callouts
+  > *Installed `remark-github-alerts` and wired it into `astro.config.ts` so all `.md` and `.mdx` posts support GitHub-style alert syntax (`> [!NOTE]`, `> [!TIP]`, `> [!WARNING]`, `> [!IMPORTANT]`, `> [!CAUTION]`). Added themed CSS in `global.css` using site CSS variables with full dark/light mode support.*
+
 - **Apr 24, 2026** - `0df71d8`: chore: replace default OG image with custom hossain-dev-bytes branding
   > *Swapped out the generic fallback OG image with a custom-branded hossain-dev-bytes image so social previews for posts without a dedicated image use the site's own identity.*
 

--- a/EMBEDS.md
+++ b/EMBEDS.md
@@ -11,6 +11,29 @@ Embeds are reusable Astro components that display rich content inline within blo
 - API data displays
 - Custom content cards
 
+## Built-in Alerts / Callouts
+
+For simple callouts and admonitions, use the built-in **GitHub-style alert syntax** — no component import needed. Works in both `.md` and `.mdx` files via the `remark-github-alerts` plugin.
+
+```markdown
+> [!NOTE]
+> Useful information readers should know, even when skimming.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+```
+
+All five types are styled with your site theme colors and support dark/light mode. Styles live in `src/styles/global.css` under the `markdown-alert` block.
+
 ## Quick Start
 
 ### 1. Create a New Embed Component
@@ -679,5 +702,5 @@ src/data/blog/
 
 ---
 
-**Last Updated**: April 5, 2026  
+**Last Updated**: April 26, 2026  
 **Author**: Development Team

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,6 +10,7 @@ import sitemap from "@astrojs/sitemap";
 import remarkToc from "remark-toc";
 import remarkCollapse from "remark-collapse";
 import { remarkReadingTime } from "./src/utils/remark-reading-time";
+import remarkGithubAlerts from "remark-github-alerts";
 
 // https://shiki.style/
 import {
@@ -38,7 +39,7 @@ export default defineConfig({
   ],
 
   markdown: {
-    remarkPlugins: [remarkReadingTime, remarkToc, [remarkCollapse, { test: "Table of contents" }]],
+    remarkPlugins: [remarkReadingTime, remarkGithubAlerts, remarkToc, [remarkCollapse, { test: "Table of contents" }]],
     shikiConfig: {
       // For more themes, visit https://shiki.style/themes
       themes: { light: "min-light", dark: "github-dark-default" },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lodash.kebabcase": "^4.1.1",
     "marked": "^18.0.0",
     "remark-collapse": "^0.1.2",
+    "remark-github-alerts": "^0.1.1",
     "remark-toc": "^9.0.0",
     "satori": "^0.19.2",
     "sharp": "^0.34.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       remark-collapse:
         specifier: ^0.1.2
         version: 0.1.2
+      remark-github-alerts:
+        specifier: ^0.1.1
+        version: 0.1.1(@types/mdast@4.0.4)(unified@11.0.5)
       remark-toc:
         specifier: ^9.0.0
         version: 9.0.0
@@ -2481,6 +2484,12 @@ packages:
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-github-alerts@0.1.1:
+    resolution: {integrity: sha512-A0NLfeAuu76ymiGIoEoBcHmqlPcdLFq+FoCGiWlzu8vkyhscyDv+pAkMA9paGr+OHpzpFflZKnsqOCvMESG/Uw==}
+    peerDependencies:
+      '@types/mdast': ^4.0.0
+      unified: ^11.0.0
 
   remark-mdx@3.1.1:
     resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
@@ -5813,6 +5822,12 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+
+  remark-github-alerts@0.1.1(@types/mdast@4.0.4)(unified@11.0.5):
+    dependencies:
+      '@types/mdast': 4.0.4
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
 
   remark-mdx@3.1.1:
     dependencies:

--- a/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx
@@ -39,6 +39,9 @@ I hosted the service at `https://syntax-highlight.gohk.xyz/docs`. It's on Cloudf
 
 Since it's just a REST API, it works for any client - Android, iOS, or web. I also built a companion [iOS demo](https://github.com/hossain-khan/ios-syntax-highlighter-swift) using the same service with SwiftUI, which follows the same pattern: call the `/highlight/dual` endpoint, get tokens back, render with `AttributedString`.
 
+> [!NOTE]
+> The service is a proof of concept. The response format is intentionally simple - if you're building something production-ready, you'd likely want to optimize the payload (e.g. compress repeated colors, batch tokens differently) to reduce response size for larger code snippets.
+
 ![Shiki Token Service rendering syntax highlighting across web, Android, and iOS clients](../../assets/images/shiki-service-compare.webp)
 
 ## The Android side

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -208,3 +208,96 @@ blockquote i {
   background: color-mix(in srgb, var(--accent) 15%, transparent);
   box-shadow: 0 4px 15px color-mix(in srgb, var(--accent) 15%, transparent);
 }
+
+/* ── GitHub-style Alerts (remark-github-alerts) ─────────────────────────────
+   Rendered HTML structure:
+     <div class="markdown-alert markdown-alert-{type}">
+       <p class="markdown-alert-title">...</p>
+       <p>...</p>
+     </div>
+   Types: note | tip | important | warning | caution
+─────────────────────────────────────────────────────────────────────────── */
+
+.markdown-alert {
+  border-left: 4px solid;
+  border-radius: 0 0.5rem 0.5rem 0;
+  padding: 0.75rem 1rem;
+  margin: 1.5rem 0;
+  background: color-mix(in srgb, currentColor 6%, var(--background));
+}
+
+.markdown-alert p:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-alert-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-top: 0 !important;
+  margin-bottom: 0.25rem !important;
+}
+
+/* Note — blue (accent) */
+.markdown-alert-note {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* Tip — green */
+.markdown-alert-tip {
+  color: #2da44e;
+  border-color: #2da44e;
+}
+
+html[data-theme="dark"] .markdown-alert-tip {
+  color: #3fb950;
+  border-color: #3fb950;
+}
+
+/* Important — purple */
+.markdown-alert-important {
+  color: #8250df;
+  border-color: #8250df;
+}
+
+html[data-theme="dark"] .markdown-alert-important {
+  color: #a371f7;
+  border-color: #a371f7;
+}
+
+/* Warning — orange/amber */
+.markdown-alert-warning {
+  color: #bf8700;
+  border-color: #bf8700;
+}
+
+html[data-theme="dark"] .markdown-alert-warning {
+  color: #d29922;
+  border-color: #d29922;
+}
+
+/* Caution — red */
+.markdown-alert-caution {
+  color: #cf222e;
+  border-color: #cf222e;
+}
+
+html[data-theme="dark"] .markdown-alert-caution {
+  color: #f85149;
+  border-color: #f85149;
+}
+
+/* Title text inherits the alert color */
+.markdown-alert-title {
+  color: inherit;
+}
+
+/* Body text uses normal foreground color */
+.markdown-alert > p:not(.markdown-alert-title) {
+  color: var(--foreground);
+}


### PR DESCRIPTION
## What

Adds GitHub-style alert/callout syntax support to all blog posts (`.md` and `.mdx`) via the `remark-github-alerts` plugin.

## Changes

- **`package.json` / `pnpm-lock.yaml`** - Added `remark-github-alerts` dependency
- **`astro.config.ts`** - Wired `remarkGithubAlerts` into `remarkPlugins`
- **`src/styles/global.css`** - Added themed styles for all 5 alert types with dark/light mode support using existing CSS variables
- **`src/data/blog/syntax-highlighting-on-android-bringing-shiki-engine-to-compose.mdx`** - Added a `[!NOTE]` callout to flag the Shiki service as a PoC
- **`CHANGELOG.md`** - Added entry for this feature
- **`EMBEDS.md`** - Added "Built-in Alerts / Callouts" section documenting the syntax

## Usage

Works in any `.md` or `.mdx` post — no imports needed:

```markdown
> [!NOTE]
> Useful information readers should know.

> [!TIP]
> Helpful advice for doing things better.

> [!IMPORTANT]
> Key information users need to know.

> [!WARNING]
> Urgent info that needs immediate attention.

> [!CAUTION]
> Advises about risks or negative outcomes.
```

## Alert styles

| Type | Color |
|------|-------|
| `NOTE` | Blue (site accent) |
| `TIP` | Green |
| `IMPORTANT` | Purple |
| `WARNING` | Amber |
| `CAUTION` | Red |

All types respect dark/light mode via `html[data-theme]` selectors.
