### PR TITLE
fix: correct showLineNumbers default in blog post (off by default)

### DIFF
--- a/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
@@ -68,7 +68,7 @@ HighlightThemeProvider(
 
 `HighlightThemeProvider` reads `isSystemInDarkTheme()` automatically and picks the right theme. You can pass `darkTheme = true/false` to force a specific mode.
 
-The composable comes with a few useful parameters out of the box - line numbers, a language badge in the header, and a copy-to-clipboard button are all on by default. You can swap in a custom copy icon or override the copy handler if you want to own that UX yourself.
+The composable comes with a few useful parameters out of the box - a language badge in the header and a copy-to-clipboard button are on by default, while line numbers are off (pass `showLineNumbers = true` to enable them). You can swap in a custom copy icon or override the copy handler if you want to own that UX yourself.
 
 ## The shared WebView design
 


### PR DESCRIPTION
## Fix

Corrects an inaccuracy in the Highlight.js blog post.

**Before:** "line numbers, a language badge in the header, and a copy-to-clipboard button are all on by default"

**After:** "a language badge in the header and a copy-to-clipboard button are on by default, while line numbers are off (pass `showLineNumbers = true` to enable them)"

### Actual defaults in `SyntaxHighlightedCode`
- `showLineNumbers: Boolean = false` ← off by default
- `showLanguageLabel: Boolean = true` ← on by default
- `showCopyButton: Boolean = true` ← on by default