### PR TITLE
fix: remove comment reference in sign-off (site has no comment support)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -261,11 +261,13 @@ Use `>` blockquotes for tips and callouts. Optionally with a 💡 prefix.
 If you personally hit issues, add a Troubleshooting section at the end with the actual errors and what fixed them.
 
 **Friendly sign-off**
-End posts with a short, warm close that invites readers to comment if something's broken or unclear. Examples:
+End posts with a short, warm close. Examples:
 
 - "Happy mocking 😃!"
 - "Hope it helps somebody. ✌️"
-- "If you find any issue, leave a comment or open a GitHub issue."
+- "If you find any issue, open a GitHub issue."
+
+> **Note**: This site does NOT have comment support. Never tell readers to "drop a comment" or "leave a comment" - direct them to GitHub issues instead.
 
 **Emoji usage**
 Use emoji sparingly and naturally - a few in the body and sign-off is fine. Don't force them into every bullet or heading.

--- a/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
@@ -126,4 +126,4 @@ The dominant cost is the WebView JS round-trip. `ThemeParser` (CSS parsing) and 
 
 It's satisfying that something I was just curious about - how do those AI apps do it? - turned into a library I can actually use in my own projects. The WebView-as-JS-engine pattern is not new, but packaging it cleanly with proper lifecycle management, theme support, and Compose integration turned out to be a worthwhile project.
 
-If you try it and run into issues, drop a comment or open a GitHub issue. Happy highlighting! ✌️
+If you try it and run into issues, open a GitHub issue. Happy highlighting! ✌️


### PR DESCRIPTION
The post sign-off said "drop a comment or open a GitHub issue" but this site has no comment support.

- Fixes the sign-off in the new blog post to say "open a GitHub issue" only
- Updates copilot-instructions.md with a note explicitly calling out that this site has no comment support, so future AI-assisted posts don't repeat this mistake