### PR TITLE
feat: add DataTable and MetricsSummary data visualization components

### DIFF
--- a/EMBEDS.md
+++ b/EMBEDS.md
@@ -658,6 +658,150 @@ downloads, and version (when available).
 
 **Data source**: `https://playbadges.pavi2410.com/app/details?id=<packageId>`
 
+## Data Visualization Components
+
+These components let you display structured data — comparison tables and metric
+summary cards — directly in MDX blog posts. Great for benchmark results, APK
+size breakdowns, before/after comparisons, or any tabular data.
+
+---
+
+### DataTable
+
+Renders a styled comparison table with an optional color-coded **Delta** column.
+Positive (`+`) deltas are red and negative (`-`) deltas are green by default
+(size/cost context where increases are bad). Pass `positiveIsGood={true}` to
+invert the logic.
+
+**Usage**:
+
+```mdx
+import DataTable from "@/components/DataTable.astro";
+
+<DataTable
+  title="Phase 2 Release Breakdown"
+  headers={["Category", "Enriched Baseline", "With Library", "Delta"]}
+  rows={[
+    { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB" },
+    { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB" },
+    { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B" },
+    { category: "res",      values: ["36.4 KB",  "36.4 KB"],   delta: "+6B" },
+    { category: "native",   values: ["84.4 KB",  "91.4 KB"],   delta: "+7 KB" },
+    { category: "asset",    values: ["3.9 KB",   "312.5 KB"],  delta: "+308.6 KB" },
+    { category: "other",    values: ["45.2 KB",  "46 KB"],     delta: "+780B" },
+    { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB", isTotal: true },
+  ]}
+/>
+```
+
+**Props**:
+
+| Prop             | Type      | Required | Default | Description                                                                              |
+| ---------------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------- |
+| `title`          | `string`  | ✅        | -       | Table title shown above the header row                                                   |
+| `headers`        | `string[]`| ✅        | -       | Column headers. First = category (left), last = delta (right), middle = value columns   |
+| `rows`           | `Row[]`   | ✅        | -       | Array of row objects (see below)                                                         |
+| `positiveIsGood` | `boolean` | ❌        | `false` | When `true`, `+` deltas are green and `-` deltas are red (e.g. for speed improvements) |
+
+**Row object shape**:
+
+| Field      | Type       | Required | Description                                          |
+| ---------- | ---------- | -------- | ---------------------------------------------------- |
+| `category` | `string`   | ✅        | Left-most cell (label/category)                      |
+| `values`   | `string[]` | ✅        | Values for each non-category, non-delta column       |
+| `delta`    | `string`   | ❌        | Delta value string, e.g. `"+235.9 KB"`, `"-32B"`   |
+| `isTotal`  | `boolean`  | ❌        | Renders the row bold (for TOTAL/summary rows)        |
+
+**Notes**:
+- The last `headers` entry is treated as the delta column header only when at least one `row` has a `delta` field.
+- Tables without any `delta` values render all columns as plain value columns.
+- Supports light and dark mode automatically.
+
+---
+
+### MetricsSummary
+
+Renders a card with a title, optional subtitle, and a responsive grid of large
+highlighted metric numbers. Best for APK impact summaries, benchmark results,
+or any set of 2-4 key figures you want to call out visually.
+
+Same color logic as `DataTable`: `+` = red (bad), `-` = green (good) by
+default. Pass `positiveIsGood={true}` to invert.
+
+**Usage**:
+
+```mdx
+import MetricsSummary from "@/components/MetricsSummary.astro";
+
+<MetricsSummary
+  title="True Library Impact (with-library vs enriched baseline)"
+  subtitle="Compared against a realistic app that already uses WebView, LazyColumn, Canvas, and animations."
+  metrics={[
+    { value: "+561.4 KB", label: "Release APK Delta" },
+    { value: "+440.1 KB", label: "Debug APK Delta" },
+    { value: "+2,708",    label: "Methods (release)" },
+    { value: "+571",      label: "Classes (release)" },
+  ]}
+/>
+```
+
+**Props**:
+
+| Prop             | Type       | Required | Default | Description                                                                              |
+| ---------------- | ---------- | -------- | ------- | ---------------------------------------------------------------------------------------- |
+| `title`          | `string`   | ✅        | -       | Card title                                                                               |
+| `subtitle`       | `string`   | ❌        | -       | Optional descriptive text shown below the title                                          |
+| `metrics`        | `Metric[]` | ✅        | -       | Array of metric objects (see below)                                                      |
+| `positiveIsGood` | `boolean`  | ❌        | `false` | When `true`, `+` values are green and `-` values are red                                |
+
+**Metric object shape**:
+
+| Field   | Type     | Required | Description                                              |
+| ------- | -------- | -------- | -------------------------------------------------------- |
+| `value` | `string` | ✅        | The big number to highlight, e.g. `"+561.4 KB"`, `"4,783"` |
+| `label` | `string` | ✅        | Short label shown below the value                        |
+
+**Notes**:
+- 2 metrics: 2-column grid. 3 metrics: 3-column grid. 4 metrics: 2×2 on mobile, 4-column on `sm+`.
+- Values without a `+` or `-` prefix are shown in the site accent color (blue).
+- Supports light and dark mode automatically.
+
+---
+
+### Combining both in a post
+
+```mdx
+import DataTable from "@/components/DataTable.astro";
+import MetricsSummary from "@/components/MetricsSummary.astro";
+
+Here's the full APK size breakdown with R8 minification:
+
+<DataTable
+  title="Release APK (with R8 minification)"
+  headers={["Category", "Baseline", "With Library", "Delta"]}
+  rows={[
+    { category: "dex",    values: ["676.1 KB", "1,062 KB"],  delta: "+385.9 KB" },
+    { category: "native", values: ["98.1 KB",  "91.4 KB"],   delta: "-6.7 KB" },
+    { category: "asset",  values: ["3.1 KB",   "312.5 KB"],  delta: "+309.5 KB" },
+    { category: "TOTAL",  values: ["930.7 KB", "1,629 KB"],  delta: "+698.7 KB", isTotal: true },
+  ]}
+/>
+
+And here's what that means in practice:
+
+<MetricsSummary
+  title="Impact Summary"
+  metrics={[
+    { value: "+698.7 KB", label: "Release APK (compressed)" },
+    { value: "+510.7 KB", label: "Debug APK (compressed)" },
+    { value: "+4,783",    label: "Methods added (release)" },
+    { value: "+1,042",    label: "Classes added (release)" },
+  ]}
+/>
+```
+
+---
+
 ## File Organization
 
 Your embed components belong in `src/components/`:
@@ -666,6 +810,8 @@ Your embed components belong in `src/components/`:
 src/components/
 ├── GitHubEmbed.astro      # GitHub repo card
 ├── GooglePlayEmbed.astro  # Google Play app card
+├── DataTable.astro        # Comparison table with color-coded delta column
+├── MetricsSummary.astro   # Large-number stats summary card
 ├── VideoEmbed.astro       # YouTube/video embed
 ├── QuoteEmbed.astro       # Pull quotes
 ├── CodepenEmbed.astro     # Codepen projects

--- a/EMBEDS.md
+++ b/EMBEDS.md
@@ -676,10 +676,8 @@ a metric) or `deltaIntent` (on a row) to one of:
 | `"OK"`      | Green  | Reductions, improvements, passing            |
 | `"NEUTRAL"` | Blue   | Informational values with no good/bad signal |
 
-When `intent` / `deltaIntent` is **omitted**, color is auto-detected from the
-value string prefix: `+` → `DANGER` (red), `-` → `OK` (green), no prefix →
-`NEUTRAL` (blue). This means most APK size / benchmark tables work without
-setting any intents at all.
+When `intent` / `deltaIntent` is omitted, the value defaults to `NEUTRAL` (blue).
+Always set intent explicitly so the meaning is clear to readers.
 
 ---
 
@@ -696,14 +694,14 @@ import DataTable from "@/components/DataTable.astro";
   title="Release Build Breakdown"
   headers={["Category", "Baseline App", "With Library", "Delta"]}
   rows={[
-    { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB" },
-    { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB" },
-    { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B" },
-    { category: "res",      values: ["36.4 KB",  "36.4 KB"],   delta: "+6B" },
-    { category: "native",   values: ["84.4 KB",  "91.4 KB"],   delta: "+7 KB" },
-    { category: "asset",    values: ["3.9 KB",   "312.5 KB"],  delta: "+308.6 KB" },
-    { category: "other",    values: ["45.2 KB",  "46 KB"],     delta: "+780B" },
-    { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB", isTotal: true },
+    { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB",  deltaIntent: "DANGER" },
+    { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB",    deltaIntent: "DANGER" },
+    { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B",        deltaIntent: "OK" },
+    { category: "res",      values: ["36.4 KB",  "36.4 KB"],   delta: "+6B",          deltaIntent: "NEUTRAL" },
+    { category: "native",   values: ["84.4 KB",  "91.4 KB"],   delta: "+7 KB",       deltaIntent: "DANGER" },
+    { category: "asset",    values: ["3.9 KB",   "312.5 KB"],  delta: "+308.6 KB",  deltaIntent: "DANGER" },
+    { category: "other",    values: ["45.2 KB",  "46 KB"],     delta: "+780B",        deltaIntent: "NEUTRAL" },
+    { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB",  deltaIntent: "DANGER", isTotal: true },
   ]}
 />
 ```
@@ -737,7 +735,7 @@ With explicit intents (e.g. a score increase is good):
 | `category`     | `string`      | ✅        | Left-most cell (label/category)                                          |
 | `values`       | `string[]`    | ✅        | Values for each non-category, non-delta column                           |
 | `delta`        | `string`      | ❌        | Delta value string, e.g. `"+235.9 KB"`, `"-32B"`                       |
-| `deltaIntent`  | `ColorIntent` | ❌        | Explicit color for the delta cell. Auto-detected from prefix if omitted  |
+| `deltaIntent`  | `ColorIntent` | ❌        | Color for the delta cell. Defaults to `NEUTRAL` if omitted               |
 | `isTotal`      | `boolean`     | ❌        | Renders the row bold (for TOTAL/summary rows)                            |
 
 **Notes**:
@@ -762,10 +760,10 @@ import MetricsSummary from "@/components/MetricsSummary.astro";
   title="True Library Impact (with-library vs baseline app)"
   subtitle="Compared against a realistic app that already uses WebView, LazyColumn, Canvas, and animations."
   metrics={[
-    { value: "+561.4 KB", label: "Release APK Delta" },
-    { value: "+440.1 KB", label: "Debug APK Delta" },
-    { value: "+2,708",    label: "Methods (release)" },
-    { value: "+571",      label: "Classes (release)" },
+    { value: "+561.4 KB", label: "Release APK Delta",  intent: "DANGER" },
+    { value: "+440.1 KB", label: "Debug APK Delta",    intent: "DANGER" },
+    { value: "+2,708",    label: "Methods (release)",  intent: "DANGER" },
+    { value: "+571",      label: "Classes (release)",  intent: "DANGER" },
   ]}
 />
 ```
@@ -798,11 +796,11 @@ With explicit intents:
 | -------- | ------------- | -------- | ----------------------------------------------------------------------- |
 | `value`  | `string`      | ✅        | The big number to highlight, e.g. `"+561.4 KB"`, `"4,783"`            |
 | `label`  | `string`      | ✅        | Short label shown below the value                                       |
-| `intent` | `ColorIntent` | ❌        | Explicit color for this metric. Auto-detected from prefix if omitted    |
+| `intent` | `ColorIntent` | ❌        | Color for this metric. Defaults to `NEUTRAL` if omitted                 |
 
 **Notes**:
 - 2 metrics: 2-column grid. 3 metrics: 3-column grid. 4 metrics: 2×2 on mobile, 4-column on `sm+`.
-- Values without a `+` or `-` prefix and no explicit `intent` are shown in the site accent color.
+- Values with no explicit `intent` default to `NEUTRAL` (site accent color).
 - Supports light and dark mode automatically.
 
 ---
@@ -819,10 +817,10 @@ Here's the full APK size breakdown:
   title="Release Build Breakdown"
   headers={["Category", "Baseline", "With Library", "Delta"]}
   rows={[
-    { category: "dex",    values: ["676.1 KB", "1,062 KB"],  delta: "+385.9 KB" },
-    { category: "native", values: ["98.1 KB",  "91.4 KB"],   delta: "-6.7 KB" },
-    { category: "asset",  values: ["3.1 KB",   "312.5 KB"],  delta: "+309.5 KB" },
-    { category: "TOTAL",  values: ["930.7 KB", "1,629 KB"],  delta: "+698.7 KB", isTotal: true },
+    { category: "dex",    values: ["676.1 KB", "1,062 KB"],  delta: "+385.9 KB",  deltaIntent: "DANGER" },
+    { category: "native", values: ["98.1 KB",  "91.4 KB"],   delta: "-6.7 KB",    deltaIntent: "OK" },
+    { category: "asset",  values: ["3.1 KB",   "312.5 KB"],  delta: "+309.5 KB",  deltaIntent: "DANGER" },
+    { category: "TOTAL",  values: ["930.7 KB", "1,629 KB"],  delta: "+698.7 KB",  deltaIntent: "DANGER", isTotal: true },
   ]}
 />
 
@@ -831,10 +829,10 @@ And here's what that means in practice:
 <MetricsSummary
   title="Impact Summary"
   metrics={[
-    { value: "+698.7 KB", label: "Release APK (compressed)" },
-    { value: "+510.7 KB", label: "Debug APK (compressed)" },
-    { value: "+4,783",    label: "Methods added (release)" },
-    { value: "+1,042",    label: "Classes added (release)" },
+    { value: "+698.7 KB", label: "Release APK (compressed)",  intent: "DANGER" },
+    { value: "+510.7 KB", label: "Debug APK (compressed)",    intent: "DANGER" },
+    { value: "+4,783",    label: "Methods added (release)",   intent: "DANGER" },
+    { value: "+1,042",    label: "Classes added (release)",   intent: "DANGER" },
   ]}
 />
 ```

--- a/EMBEDS.md
+++ b/EMBEDS.md
@@ -664,14 +664,28 @@ These components let you display structured data — comparison tables and metri
 summary cards — directly in MDX blog posts. Great for benchmark results, APK
 size breakdowns, before/after comparisons, or any tabular data.
 
+### Color intents
+
+Both components share the same explicit color intent system. Set `intent` (on
+a metric) or `deltaIntent` (on a row) to one of:
+
+| Intent      | Color  | Use for                                      |
+| ----------- | ------ | -------------------------------------------- |
+| `"DANGER"`  | Red    | Increases, failures, cost, regressions       |
+| `"WARN"`    | Orange | Notable but not critical changes             |
+| `"OK"`      | Green  | Reductions, improvements, passing            |
+| `"NEUTRAL"` | Blue   | Informational values with no good/bad signal |
+
+When `intent` / `deltaIntent` is **omitted**, color is auto-detected from the
+value string prefix: `+` → `DANGER` (red), `-` → `OK` (green), no prefix →
+`NEUTRAL` (blue). This means most APK size / benchmark tables work without
+setting any intents at all.
+
 ---
 
 ### DataTable
 
 Renders a styled comparison table with an optional color-coded **Delta** column.
-Positive (`+`) deltas are red and negative (`-`) deltas are green by default
-(size/cost context where increases are bad). Pass `positiveIsGood={true}` to
-invert the logic.
 
 **Usage**:
 
@@ -679,8 +693,8 @@ invert the logic.
 import DataTable from "@/components/DataTable.astro";
 
 <DataTable
-  title="Phase 2 Release Breakdown"
-  headers={["Category", "Enriched Baseline", "With Library", "Delta"]}
+  title="Release Build Breakdown"
+  headers={["Category", "Baseline App", "With Library", "Delta"]}
   rows={[
     { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB" },
     { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB" },
@@ -694,23 +708,37 @@ import DataTable from "@/components/DataTable.astro";
 />
 ```
 
+With explicit intents (e.g. a score increase is good):
+
+```mdx
+<DataTable
+  title="Benchmark Results"
+  headers={["Test", "Before", "After", "Delta"]}
+  rows={[
+    { category: "Render time", values: ["42ms", "28ms"], delta: "-14ms",  deltaIntent: "OK" },
+    { category: "Memory",      values: ["48MB", "51MB"], delta: "+3MB",   deltaIntent: "WARN" },
+    { category: "Score",       values: ["72",   "89"],   delta: "+17",    deltaIntent: "OK" },
+  ]}
+/>
+```
+
 **Props**:
 
-| Prop             | Type      | Required | Default | Description                                                                              |
-| ---------------- | --------- | -------- | ------- | ---------------------------------------------------------------------------------------- |
-| `title`          | `string`  | ✅        | -       | Table title shown above the header row                                                   |
-| `headers`        | `string[]`| ✅        | -       | Column headers. First = category (left), last = delta (right), middle = value columns   |
-| `rows`           | `Row[]`   | ✅        | -       | Array of row objects (see below)                                                         |
-| `positiveIsGood` | `boolean` | ❌        | `false` | When `true`, `+` deltas are green and `-` deltas are red (e.g. for speed improvements) |
+| Prop      | Type      | Required | Description                                                                             |
+| --------- | --------- | -------- | --------------------------------------------------------------------------------------- |
+| `title`   | `string`  | ✅        | Table title shown above the header row                                                  |
+| `headers` | `string[]`| ✅        | Column headers. First = category (left), last = delta (right), middle = value columns  |
+| `rows`    | `Row[]`   | ✅        | Array of row objects (see below)                                                        |
 
 **Row object shape**:
 
-| Field      | Type       | Required | Description                                          |
-| ---------- | ---------- | -------- | ---------------------------------------------------- |
-| `category` | `string`   | ✅        | Left-most cell (label/category)                      |
-| `values`   | `string[]` | ✅        | Values for each non-category, non-delta column       |
-| `delta`    | `string`   | ❌        | Delta value string, e.g. `"+235.9 KB"`, `"-32B"`   |
-| `isTotal`  | `boolean`  | ❌        | Renders the row bold (for TOTAL/summary rows)        |
+| Field          | Type          | Required | Description                                                              |
+| -------------- | ------------- | -------- | ------------------------------------------------------------------------ |
+| `category`     | `string`      | ✅        | Left-most cell (label/category)                                          |
+| `values`       | `string[]`    | ✅        | Values for each non-category, non-delta column                           |
+| `delta`        | `string`      | ❌        | Delta value string, e.g. `"+235.9 KB"`, `"-32B"`                       |
+| `deltaIntent`  | `ColorIntent` | ❌        | Explicit color for the delta cell. Auto-detected from prefix if omitted  |
+| `isTotal`      | `boolean`     | ❌        | Renders the row bold (for TOTAL/summary rows)                            |
 
 **Notes**:
 - The last `headers` entry is treated as the delta column header only when at least one `row` has a `delta` field.
@@ -725,16 +753,13 @@ Renders a card with a title, optional subtitle, and a responsive grid of large
 highlighted metric numbers. Best for APK impact summaries, benchmark results,
 or any set of 2-4 key figures you want to call out visually.
 
-Same color logic as `DataTable`: `+` = red (bad), `-` = green (good) by
-default. Pass `positiveIsGood={true}` to invert.
-
 **Usage**:
 
 ```mdx
 import MetricsSummary from "@/components/MetricsSummary.astro";
 
 <MetricsSummary
-  title="True Library Impact (with-library vs enriched baseline)"
+  title="True Library Impact (with-library vs baseline app)"
   subtitle="Compared against a realistic app that already uses WebView, LazyColumn, Canvas, and animations."
   metrics={[
     { value: "+561.4 KB", label: "Release APK Delta" },
@@ -745,25 +770,39 @@ import MetricsSummary from "@/components/MetricsSummary.astro";
 />
 ```
 
+With explicit intents:
+
+```mdx
+<MetricsSummary
+  title="Test Suite Results"
+  metrics={[
+    { value: "98.4%",  label: "Tests passing",    intent: "OK" },
+    { value: "3",      label: "Tests failing",     intent: "DANGER" },
+    { value: "12",     label: "Tests skipped",     intent: "WARN" },
+    { value: "1,042",  label: "Total test cases",  intent: "NEUTRAL" },
+  ]}
+/>
+```
+
 **Props**:
 
-| Prop             | Type       | Required | Default | Description                                                                              |
-| ---------------- | ---------- | -------- | ------- | ---------------------------------------------------------------------------------------- |
-| `title`          | `string`   | ✅        | -       | Card title                                                                               |
-| `subtitle`       | `string`   | ❌        | -       | Optional descriptive text shown below the title                                          |
-| `metrics`        | `Metric[]` | ✅        | -       | Array of metric objects (see below)                                                      |
-| `positiveIsGood` | `boolean`  | ❌        | `false` | When `true`, `+` values are green and `-` values are red                                |
+| Prop       | Type       | Required | Description                                      |
+| ---------- | ---------- | -------- | ------------------------------------------------ |
+| `title`    | `string`   | ✅        | Card title                                       |
+| `subtitle` | `string`   | ❌        | Optional descriptive text shown below the title  |
+| `metrics`  | `Metric[]` | ✅        | Array of metric objects (see below)              |
 
 **Metric object shape**:
 
-| Field   | Type     | Required | Description                                              |
-| ------- | -------- | -------- | -------------------------------------------------------- |
-| `value` | `string` | ✅        | The big number to highlight, e.g. `"+561.4 KB"`, `"4,783"` |
-| `label` | `string` | ✅        | Short label shown below the value                        |
+| Field    | Type          | Required | Description                                                             |
+| -------- | ------------- | -------- | ----------------------------------------------------------------------- |
+| `value`  | `string`      | ✅        | The big number to highlight, e.g. `"+561.4 KB"`, `"4,783"`            |
+| `label`  | `string`      | ✅        | Short label shown below the value                                       |
+| `intent` | `ColorIntent` | ❌        | Explicit color for this metric. Auto-detected from prefix if omitted    |
 
 **Notes**:
 - 2 metrics: 2-column grid. 3 metrics: 3-column grid. 4 metrics: 2×2 on mobile, 4-column on `sm+`.
-- Values without a `+` or `-` prefix are shown in the site accent color (blue).
+- Values without a `+` or `-` prefix and no explicit `intent` are shown in the site accent color.
 - Supports light and dark mode automatically.
 
 ---
@@ -774,10 +813,10 @@ import MetricsSummary from "@/components/MetricsSummary.astro";
 import DataTable from "@/components/DataTable.astro";
 import MetricsSummary from "@/components/MetricsSummary.astro";
 
-Here's the full APK size breakdown with R8 minification:
+Here's the full APK size breakdown:
 
 <DataTable
-  title="Release APK (with R8 minification)"
+  title="Release Build Breakdown"
   headers={["Category", "Baseline", "With Library", "Delta"]}
   rows={[
     { category: "dex",    values: ["676.1 KB", "1,062 KB"],  delta: "+385.9 KB" },

--- a/src/components/DataTable.astro
+++ b/src/components/DataTable.astro
@@ -78,7 +78,7 @@ const deltaHeader = hasDelta ? headers[headers.length - 1] : null;
 ---
 
 <div
-  class="not-prose my-6 overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60"
+  class="not-prose my-6 overflow-x-auto rounded-xl border border-slate-300/40 bg-slate-100/40 shadow-sm dark:border-slate-700/30 dark:bg-slate-800/30"
 >
   <div class="px-5 pt-5 pb-3">
     <h3
@@ -88,12 +88,12 @@ const deltaHeader = hasDelta ? headers[headers.length - 1] : null;
     </h3>
   </div>
 
-  <table class="w-full border-collapse text-sm">
+  <table class="w-full border-0 border-collapse text-sm">
     <thead>
-      <tr class="border-b border-slate-200 dark:border-slate-700">
+      <tr class="border-b border-0 border-b-slate-300/50 dark:border-b-slate-600/40">
         <!-- Category header -->
         <th
-          class="px-5 py-2.5 text-left font-semibold text-slate-700 dark:text-slate-300"
+          class="border-0 px-5 py-2.5 text-left font-semibold text-slate-600 dark:text-slate-400"
         >
           {headers[0]}
         </th>
@@ -101,7 +101,7 @@ const deltaHeader = hasDelta ? headers[headers.length - 1] : null;
         <!-- Value column headers -->
         {
           valueHeaders.map(h => (
-            <th class="px-5 py-2.5 text-right font-semibold text-slate-700 dark:text-slate-300">
+            <th class="border-0 px-5 py-2.5 text-right font-semibold text-slate-600 dark:text-slate-400">
               {h}
             </th>
           ))
@@ -110,7 +110,7 @@ const deltaHeader = hasDelta ? headers[headers.length - 1] : null;
         <!-- Delta header -->
         {
           deltaHeader && (
-            <th class="px-5 py-2.5 text-right font-semibold text-slate-700 dark:text-slate-300">
+            <th class="border-0 px-5 py-2.5 text-right font-semibold text-slate-600 dark:text-slate-400">
               {deltaHeader}
             </th>
           )
@@ -120,21 +120,17 @@ const deltaHeader = hasDelta ? headers[headers.length - 1] : null;
 
     <tbody>
       {
-        rows.map((row, i) => (
+        rows.map(row => (
           <tr
             class:list={[
-              "border-b border-slate-100 last:border-0 dark:border-slate-800",
-              row.isTotal
-                ? "bg-slate-50/60 dark:bg-slate-800/40"
-                : i % 2 === 0
-                  ? ""
-                  : "",
+              "border-0 border-b border-b-slate-200/60 last:border-0 dark:border-b-slate-700/30",
+              row.isTotal ? "bg-slate-200/30 dark:bg-slate-700/20" : "",
             ]}
           >
             <!-- Category cell -->
             <td
               class:list={[
-                "px-5 py-3 text-left text-slate-800 dark:text-slate-200",
+                "border-0 px-5 py-3 text-left text-slate-800 dark:text-slate-200",
                 row.isTotal ? "font-bold" : "",
               ]}
             >
@@ -145,7 +141,7 @@ const deltaHeader = hasDelta ? headers[headers.length - 1] : null;
             {row.values.map(v => (
               <td
                 class:list={[
-                  "px-5 py-3 text-right tabular-nums text-slate-700 dark:text-slate-300",
+                  "border-0 px-5 py-3 text-right tabular-nums text-slate-700 dark:text-slate-300",
                   row.isTotal ? "font-bold" : "",
                 ]}
               >
@@ -157,7 +153,7 @@ const deltaHeader = hasDelta ? headers[headers.length - 1] : null;
             {hasDelta && (
               <td
                 class:list={[
-                  "px-5 py-3 text-right tabular-nums font-semibold",
+                  "border-0 px-5 py-3 text-right tabular-nums font-semibold",
                   row.isTotal ? "font-bold" : "",
                   deltaColor(row.delta),
                 ]}

--- a/src/components/DataTable.astro
+++ b/src/components/DataTable.astro
@@ -2,25 +2,34 @@
 /**
  * DataTable — Renders a styled comparison table with an optional color-coded delta column.
  *
- * Positive deltas (+) are shown in red (increase/bad by default).
- * Negative deltas (-) are shown in green (decrease/good by default).
- * Set `positiveIsGood={true}` to invert the color logic (e.g. for performance gains).
+ * Delta color is determined by an explicit `deltaIntent` per row:
+ *   - "DANGER"  → red    (increases, failures, cost)
+ *   - "WARN"    → orange (notable but not critical)
+ *   - "OK"      → green  (reductions, improvements)
+ *   - "NEUTRAL" → accent blue (informational)
+ *
+ * When `deltaIntent` is omitted, color is inferred from the delta string prefix:
+ *   - "+" prefix → DANGER (red)
+ *   - "-" prefix → OK (green)
+ *   - no prefix  → NEUTRAL (accent blue)
  *
  * Usage in .mdx files:
  *
  *   import DataTable from '@/components/DataTable.astro';
  *
  *   <DataTable
- *     title="Phase 2 Release Breakdown"
- *     headers={["Category", "Enriched Baseline", "With Library", "Delta"]}
+ *     title="Release Build Breakdown"
+ *     headers={["Category", "Baseline App", "With Library", "Delta"]}
  *     rows={[
  *       { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB" },
- *       { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB" },
  *       { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B" },
+ *       { category: "score",    values: ["72",       "89"],         delta: "+17", deltaIntent: "OK" },
  *       { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB", isTotal: true },
  *     ]}
  *   />
  */
+
+type ColorIntent = "DANGER" | "WARN" | "OK" | "NEUTRAL";
 
 type Row = {
   /** Left-most cell (category/label column). */
@@ -29,6 +38,11 @@ type Row = {
   values: string[];
   /** Delta value string, e.g. "+235.9 KB", "-32B", "0 B". */
   delta?: string;
+  /**
+   * Explicit color intent for the delta cell.
+   * When omitted, color is auto-detected from the delta string prefix.
+   */
+  deltaIntent?: ColorIntent;
   /** When true the row is rendered bold (useful for TOTAL rows). */
   isTotal?: boolean;
 };
@@ -44,29 +58,25 @@ type Props = {
    */
   headers: string[];
   rows: Row[];
-  /**
-   * When true, "+" deltas are green and "-" deltas are red.
-   * Default false (APK / size context where increases are bad).
-   */
-  positiveIsGood?: boolean;
+  // NOTE: positiveIsGood removed — use explicit `deltaIntent` per row instead.
 };
 
-const { title, headers, rows, positiveIsGood = false } = Astro.props;
+const { title, headers, rows } = Astro.props;
 
-function deltaColor(delta: string | undefined): string {
+function intentColor(intent: ColorIntent): string {
+  switch (intent) {
+    case "DANGER":  return "text-red-500 dark:text-red-400";
+    case "WARN":    return "text-orange-500 dark:text-orange-400";
+    case "OK":      return "text-green-600 dark:text-green-400";
+    case "NEUTRAL": return "text-accent";
+  }
+}
+
+function deltaColor(delta: string | undefined, intent?: ColorIntent): string {
   if (!delta) return "";
-  const isIncrease = delta.startsWith("+");
-  const isDecrease = delta.startsWith("-");
-  if (isIncrease) {
-    return positiveIsGood
-      ? "text-green-600 dark:text-green-400"
-      : "text-red-500 dark:text-red-400";
-  }
-  if (isDecrease) {
-    return positiveIsGood
-      ? "text-red-500 dark:text-red-400"
-      : "text-green-600 dark:text-green-400";
-  }
+  if (intent) return intentColor(intent);
+  if (delta.startsWith("+")) return "text-red-500 dark:text-red-400";
+  if (delta.startsWith("-")) return "text-green-600 dark:text-green-400";
   return "text-slate-500 dark:text-slate-400";
 }
 
@@ -155,7 +165,7 @@ const deltaHeader = hasDelta ? headers[headers.length - 1] : null;
                 class:list={[
                   "border-0 px-5 py-3 text-right tabular-nums font-semibold",
                   row.isTotal ? "font-bold" : "",
-                  deltaColor(row.delta),
+                  deltaColor(row.delta, row.deltaIntent),
                 ]}
               >
                 {row.delta ?? ""}

--- a/src/components/DataTable.astro
+++ b/src/components/DataTable.astro
@@ -59,7 +59,7 @@ const { title, headers, rows } = Astro.props;
 
 function deltaColor(intent?: ColorIntent): string {
   switch (intent) {
-    case "DANGER":  return "text-red-500 dark:text-red-400";
+    case "DANGER":  return "text-(--color-red-400)";
     case "WARN":    return "text-orange-500 dark:text-orange-400";
     case "OK":      return "text-green-600 dark:text-green-400";
     case "NEUTRAL":

--- a/src/components/DataTable.astro
+++ b/src/components/DataTable.astro
@@ -1,0 +1,173 @@
+---
+/**
+ * DataTable — Renders a styled comparison table with an optional color-coded delta column.
+ *
+ * Positive deltas (+) are shown in red (increase/bad by default).
+ * Negative deltas (-) are shown in green (decrease/good by default).
+ * Set `positiveIsGood={true}` to invert the color logic (e.g. for performance gains).
+ *
+ * Usage in .mdx files:
+ *
+ *   import DataTable from '@/components/DataTable.astro';
+ *
+ *   <DataTable
+ *     title="Phase 2 Release Breakdown"
+ *     headers={["Category", "Enriched Baseline", "With Library", "Delta"]}
+ *     rows={[
+ *       { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB" },
+ *       { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB" },
+ *       { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B" },
+ *       { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB", isTotal: true },
+ *     ]}
+ *   />
+ */
+
+type Row = {
+  /** Left-most cell (category/label column). */
+  category: string;
+  /** Values for each non-category, non-delta column — in header order. */
+  values: string[];
+  /** Delta value string, e.g. "+235.9 KB", "-32B", "0 B". */
+  delta?: string;
+  /** When true the row is rendered bold (useful for TOTAL rows). */
+  isTotal?: boolean;
+};
+
+type Props = {
+  /** Table title shown above the header row. */
+  title: string;
+  /**
+   * Column headers.
+   * First header = category column (left-aligned).
+   * Last header = delta column (right-aligned, colored) if `rows` have a `delta` field.
+   * Middle headers = value columns (right-aligned).
+   */
+  headers: string[];
+  rows: Row[];
+  /**
+   * When true, "+" deltas are green and "-" deltas are red.
+   * Default false (APK / size context where increases are bad).
+   */
+  positiveIsGood?: boolean;
+};
+
+const { title, headers, rows, positiveIsGood = false } = Astro.props;
+
+function deltaColor(delta: string | undefined): string {
+  if (!delta) return "";
+  const isIncrease = delta.startsWith("+");
+  const isDecrease = delta.startsWith("-");
+  if (isIncrease) {
+    return positiveIsGood
+      ? "text-green-600 dark:text-green-400"
+      : "text-red-500 dark:text-red-400";
+  }
+  if (isDecrease) {
+    return positiveIsGood
+      ? "text-red-500 dark:text-red-400"
+      : "text-green-600 dark:text-green-400";
+  }
+  return "text-slate-500 dark:text-slate-400";
+}
+
+// Number of value columns = headers.length - 1 (category) - 1 (delta) = headers.length - 2
+// But if no rows have deltas, treat last header as a plain value column.
+const hasDelta = rows.some(r => r.delta !== undefined);
+const valueHeaders = hasDelta ? headers.slice(1, -1) : headers.slice(1);
+const deltaHeader = hasDelta ? headers[headers.length - 1] : null;
+---
+
+<div
+  class="not-prose my-6 overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60"
+>
+  <div class="px-5 pt-5 pb-3">
+    <h3
+      class="m-0 text-base font-bold text-slate-900 dark:text-slate-100"
+    >
+      {title}
+    </h3>
+  </div>
+
+  <table class="w-full border-collapse text-sm">
+    <thead>
+      <tr class="border-b border-slate-200 dark:border-slate-700">
+        <!-- Category header -->
+        <th
+          class="px-5 py-2.5 text-left font-semibold text-slate-700 dark:text-slate-300"
+        >
+          {headers[0]}
+        </th>
+
+        <!-- Value column headers -->
+        {
+          valueHeaders.map(h => (
+            <th class="px-5 py-2.5 text-right font-semibold text-slate-700 dark:text-slate-300">
+              {h}
+            </th>
+          ))
+        }
+
+        <!-- Delta header -->
+        {
+          deltaHeader && (
+            <th class="px-5 py-2.5 text-right font-semibold text-slate-700 dark:text-slate-300">
+              {deltaHeader}
+            </th>
+          )
+        }
+      </tr>
+    </thead>
+
+    <tbody>
+      {
+        rows.map((row, i) => (
+          <tr
+            class:list={[
+              "border-b border-slate-100 last:border-0 dark:border-slate-800",
+              row.isTotal
+                ? "bg-slate-50/60 dark:bg-slate-800/40"
+                : i % 2 === 0
+                  ? ""
+                  : "",
+            ]}
+          >
+            <!-- Category cell -->
+            <td
+              class:list={[
+                "px-5 py-3 text-left text-slate-800 dark:text-slate-200",
+                row.isTotal ? "font-bold" : "",
+              ]}
+            >
+              {row.category}
+            </td>
+
+            <!-- Value cells -->
+            {row.values.map(v => (
+              <td
+                class:list={[
+                  "px-5 py-3 text-right tabular-nums text-slate-700 dark:text-slate-300",
+                  row.isTotal ? "font-bold" : "",
+                ]}
+              >
+                {v}
+              </td>
+            ))}
+
+            <!-- Delta cell -->
+            {hasDelta && (
+              <td
+                class:list={[
+                  "px-5 py-3 text-right tabular-nums font-semibold",
+                  row.isTotal ? "font-bold" : "",
+                  deltaColor(row.delta),
+                ]}
+              >
+                {row.delta ?? ""}
+              </td>
+            )}
+          </tr>
+        ))
+      }
+    </tbody>
+  </table>
+</div>

--- a/src/components/DataTable.astro
+++ b/src/components/DataTable.astro
@@ -2,16 +2,11 @@
 /**
  * DataTable — Renders a styled comparison table with an optional color-coded delta column.
  *
- * Delta color is determined by an explicit `deltaIntent` per row:
+ * Delta color is controlled by `deltaIntent` per row (required when `delta` is set):
  *   - "DANGER"  → red    (increases, failures, cost)
  *   - "WARN"    → orange (notable but not critical)
  *   - "OK"      → green  (reductions, improvements)
  *   - "NEUTRAL" → accent blue (informational)
- *
- * When `deltaIntent` is omitted, color is inferred from the delta string prefix:
- *   - "+" prefix → DANGER (red)
- *   - "-" prefix → OK (green)
- *   - no prefix  → NEUTRAL (accent blue)
  *
  * Usage in .mdx files:
  *
@@ -21,10 +16,10 @@
  *     title="Release Build Breakdown"
  *     headers={["Category", "Baseline App", "With Library", "Delta"]}
  *     rows={[
- *       { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB" },
- *       { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B" },
- *       { category: "score",    values: ["72",       "89"],         delta: "+17", deltaIntent: "OK" },
- *       { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB", isTotal: true },
+ *       { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB", deltaIntent: "DANGER" },
+ *       { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B",       deltaIntent: "OK" },
+ *       { category: "score",    values: ["72",       "89"],         delta: "+17",        deltaIntent: "OK" },
+ *       { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB",  deltaIntent: "DANGER", isTotal: true },
  *     ]}
  *   />
  */
@@ -39,8 +34,8 @@ type Row = {
   /** Delta value string, e.g. "+235.9 KB", "-32B", "0 B". */
   delta?: string;
   /**
-   * Explicit color intent for the delta cell.
-   * When omitted, color is auto-detected from the delta string prefix.
+   * Color intent for the delta cell. Should be set whenever `delta` is set.
+   * Defaults to NEUTRAL (accent blue) when omitted.
    */
   deltaIntent?: ColorIntent;
   /** When true the row is rendered bold (useful for TOTAL rows). */
@@ -58,26 +53,18 @@ type Props = {
    */
   headers: string[];
   rows: Row[];
-  // NOTE: positiveIsGood removed — use explicit `deltaIntent` per row instead.
 };
 
 const { title, headers, rows } = Astro.props;
 
-function intentColor(intent: ColorIntent): string {
+function deltaColor(intent?: ColorIntent): string {
   switch (intent) {
     case "DANGER":  return "text-red-500 dark:text-red-400";
     case "WARN":    return "text-orange-500 dark:text-orange-400";
     case "OK":      return "text-green-600 dark:text-green-400";
-    case "NEUTRAL": return "text-accent";
+    case "NEUTRAL":
+    default:        return "text-accent";
   }
-}
-
-function deltaColor(delta: string | undefined, intent?: ColorIntent): string {
-  if (!delta) return "";
-  if (intent) return intentColor(intent);
-  if (delta.startsWith("+")) return "text-red-500 dark:text-red-400";
-  if (delta.startsWith("-")) return "text-green-600 dark:text-green-400";
-  return "text-slate-500 dark:text-slate-400";
 }
 
 // Number of value columns = headers.length - 1 (category) - 1 (delta) = headers.length - 2
@@ -165,7 +152,7 @@ const deltaHeader = hasDelta ? headers[headers.length - 1] : null;
                 class:list={[
                   "border-0 px-5 py-3 text-right tabular-nums font-semibold",
                   row.isTotal ? "font-bold" : "",
-                  deltaColor(row.delta, row.deltaIntent),
+                  deltaColor(row.deltaIntent),
                 ]}
               >
                 {row.delta ?? ""}

--- a/src/components/MetricsSummary.astro
+++ b/src/components/MetricsSummary.astro
@@ -4,33 +4,45 @@
  * large highlighted metric numbers — useful for APK size impact summaries,
  * benchmark results, or any before/after stats.
  *
- * Metric values are colored automatically:
- *   - "+" prefix  → red   (increase / bad by default)
- *   - "-" prefix  → green (decrease / good by default)
- *   - No prefix   → accent blue
- * Set `positiveIsGood={true}` to invert the +/- color logic.
+ * Metric color is determined by an explicit `intent` per metric:
+ *   - "DANGER"  → red    (increases, failures, cost)
+ *   - "WARN"    → orange (notable but not critical)
+ *   - "OK"      → green  (reductions, improvements)
+ *   - "NEUTRAL" → accent blue (informational, default)
+ *
+ * When `intent` is omitted, color is inferred from the value string prefix:
+ *   - "+" prefix → DANGER (red)
+ *   - "-" prefix → OK (green)
+ *   - no prefix  → NEUTRAL (accent blue)
  *
  * Usage in .mdx files:
  *
  *   import MetricsSummary from '@/components/MetricsSummary.astro';
  *
  *   <MetricsSummary
- *     title="True Library Impact (with-library vs enriched baseline)"
- *     subtitle="Compared against a realistic app that already uses WebView, LazyColumn, Canvas, and animations."
+ *     title="True Library Impact"
+ *     subtitle="Compared against a realistic baseline app."
  *     metrics={[
  *       { value: "+561.4 KB", label: "Release APK Delta" },
  *       { value: "+440.1 KB", label: "Debug APK Delta" },
- *       { value: "+2,708",    label: "Methods (release)" },
- *       { value: "+571",      label: "Classes (release)" },
+ *       { value: "4,783",     label: "Total methods",   intent: "NEUTRAL" },
+ *       { value: "-32B",      label: "Manifest delta",  intent: "OK" },
  *     ]}
  *   />
  */
+
+type ColorIntent = "DANGER" | "WARN" | "OK" | "NEUTRAL";
 
 type Metric = {
   /** The big number / value to highlight, e.g. "+561.4 KB", "-32B", "4,783". */
   value: string;
   /** Short label shown below the value, e.g. "Release APK Delta". */
   label: string;
+  /**
+   * Explicit color intent for this metric.
+   * When omitted, color is auto-detected from the value string prefix.
+   */
+  intent?: ColorIntent;
 };
 
 type Props = {
@@ -40,27 +52,29 @@ type Props = {
   subtitle?: string;
   /** Array of metrics to display in the grid. 2–4 items look best. */
   metrics: Metric[];
-  /**
-   * When true, "+" values are green and "-" values are red.
-   * Default false (size / cost context where increases are bad).
-   */
-  positiveIsGood?: boolean;
+  // NOTE: positiveIsGood removed — use explicit `intent` per metric instead.
 };
 
-const { title, subtitle, metrics, positiveIsGood = false } = Astro.props;
+const { title, subtitle, metrics } = Astro.props;
 
-function valueColor(value: string): string {
+function intentColor(intent: ColorIntent): string {
+  switch (intent) {
+    case "DANGER":  return "text-red-500 dark:text-red-400";
+    case "WARN":    return "text-orange-500 dark:text-orange-400";
+    case "OK":      return "text-green-600 dark:text-green-400";
+    case "NEUTRAL": return "text-accent";
+  }
+}
+
+function valueColor(value: string, intent?: ColorIntent): string {
+  if (intent) return intentColor(intent);
   const isIncrease = value.trimStart().startsWith("+");
   const isDecrease = value.trimStart().startsWith("-");
   if (isIncrease) {
-    return positiveIsGood
-      ? "text-green-600 dark:text-green-400"
-      : "text-red-500 dark:text-red-400";
+    return "text-red-500 dark:text-red-400";
   }
   if (isDecrease) {
-    return positiveIsGood
-      ? "text-red-500 dark:text-red-400"
-      : "text-green-600 dark:text-green-400";
+    return "text-green-600 dark:text-green-400";
   }
   return "text-accent";
 }
@@ -99,7 +113,7 @@ const gridCols =
           <span
             class:list={[
               "text-2xl font-bold tabular-nums leading-tight",
-              valueColor(metric.value),
+              valueColor(metric.value, metric.intent),
             ]}
           >
             {metric.value}

--- a/src/components/MetricsSummary.astro
+++ b/src/components/MetricsSummary.astro
@@ -1,0 +1,114 @@
+---
+/**
+ * MetricsSummary — Renders a card with a title, optional subtitle, and a grid of
+ * large highlighted metric numbers — useful for APK size impact summaries,
+ * benchmark results, or any before/after stats.
+ *
+ * Metric values are colored automatically:
+ *   - "+" prefix  → red   (increase / bad by default)
+ *   - "-" prefix  → green (decrease / good by default)
+ *   - No prefix   → accent blue
+ * Set `positiveIsGood={true}` to invert the +/- color logic.
+ *
+ * Usage in .mdx files:
+ *
+ *   import MetricsSummary from '@/components/MetricsSummary.astro';
+ *
+ *   <MetricsSummary
+ *     title="True Library Impact (with-library vs enriched baseline)"
+ *     subtitle="Compared against a realistic app that already uses WebView, LazyColumn, Canvas, and animations."
+ *     metrics={[
+ *       { value: "+561.4 KB", label: "Release APK Delta" },
+ *       { value: "+440.1 KB", label: "Debug APK Delta" },
+ *       { value: "+2,708",    label: "Methods (release)" },
+ *       { value: "+571",      label: "Classes (release)" },
+ *     ]}
+ *   />
+ */
+
+type Metric = {
+  /** The big number / value to highlight, e.g. "+561.4 KB", "-32B", "4,783". */
+  value: string;
+  /** Short label shown below the value, e.g. "Release APK Delta". */
+  label: string;
+};
+
+type Props = {
+  /** Card title. */
+  title: string;
+  /** Optional descriptive subtitle shown below the title. */
+  subtitle?: string;
+  /** Array of metrics to display in the grid. 2–4 items look best. */
+  metrics: Metric[];
+  /**
+   * When true, "+" values are green and "-" values are red.
+   * Default false (size / cost context where increases are bad).
+   */
+  positiveIsGood?: boolean;
+};
+
+const { title, subtitle, metrics, positiveIsGood = false } = Astro.props;
+
+function valueColor(value: string): string {
+  const isIncrease = value.trimStart().startsWith("+");
+  const isDecrease = value.trimStart().startsWith("-");
+  if (isIncrease) {
+    return positiveIsGood
+      ? "text-green-600 dark:text-green-400"
+      : "text-red-500 dark:text-red-400";
+  }
+  if (isDecrease) {
+    return positiveIsGood
+      ? "text-red-500 dark:text-red-400"
+      : "text-green-600 dark:text-green-400";
+  }
+  return "text-accent";
+}
+
+// Responsive grid: 2 cols on small screens, up to 4 on md+
+const gridCols =
+  metrics.length <= 2
+    ? "grid-cols-1 sm:grid-cols-2"
+    : metrics.length === 3
+      ? "grid-cols-1 sm:grid-cols-3"
+      : "grid-cols-2 sm:grid-cols-4";
+---
+
+<div
+  class="not-prose my-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60"
+>
+  <!-- Title -->
+  <h3 class="m-0 text-base font-bold text-slate-900 dark:text-slate-100">
+    {title}
+  </h3>
+
+  <!-- Subtitle -->
+  {
+    subtitle && (
+      <p class="mt-1 mb-4 text-sm text-slate-500 dark:text-slate-400">
+        {subtitle}
+      </p>
+    )
+  }
+
+  <!-- Metrics grid -->
+  <div class:list={["mt-4 grid gap-3", gridCols]}>
+    {
+      metrics.map(metric => (
+        <div class="flex flex-col items-center justify-center rounded-lg bg-slate-100/80 px-4 py-4 text-center dark:bg-slate-800/60">
+          <span
+            class:list={[
+              "text-2xl font-bold tabular-nums leading-tight",
+              valueColor(metric.value),
+            ]}
+          >
+            {metric.value}
+          </span>
+          <span class="mt-1 text-xs font-semibold text-slate-600 dark:text-slate-400">
+            {metric.label}
+          </span>
+        </div>
+      ))
+    }
+  </div>
+</div>

--- a/src/components/MetricsSummary.astro
+++ b/src/components/MetricsSummary.astro
@@ -75,7 +75,7 @@ const gridCols =
 ---
 
 <div
-  class="not-prose my-6 rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/60"
+  class="not-prose my-6 rounded-xl border border-slate-300/40 bg-slate-100/40 p-5 shadow-sm dark:border-slate-700/30 dark:bg-slate-800/30"
 >
   <!-- Title -->
   <h3 class="m-0 text-base font-bold text-slate-900 dark:text-slate-100">
@@ -95,7 +95,7 @@ const gridCols =
   <div class:list={["mt-4 grid gap-3", gridCols]}>
     {
       metrics.map(metric => (
-        <div class="flex flex-col items-center justify-center rounded-lg bg-slate-100/80 px-4 py-4 text-center dark:bg-slate-800/60">
+        <div class="flex flex-col items-center justify-center rounded-lg bg-white/70 px-4 py-4 text-center dark:bg-slate-700/30">
           <span
             class:list={[
               "text-2xl font-bold tabular-nums leading-tight",

--- a/src/components/MetricsSummary.astro
+++ b/src/components/MetricsSummary.astro
@@ -4,16 +4,11 @@
  * large highlighted metric numbers — useful for APK size impact summaries,
  * benchmark results, or any before/after stats.
  *
- * Metric color is determined by an explicit `intent` per metric:
+ * Metric color is controlled by `intent` per metric (required for meaningful display):
  *   - "DANGER"  → red    (increases, failures, cost)
  *   - "WARN"    → orange (notable but not critical)
  *   - "OK"      → green  (reductions, improvements)
  *   - "NEUTRAL" → accent blue (informational, default)
- *
- * When `intent` is omitted, color is inferred from the value string prefix:
- *   - "+" prefix → DANGER (red)
- *   - "-" prefix → OK (green)
- *   - no prefix  → NEUTRAL (accent blue)
  *
  * Usage in .mdx files:
  *
@@ -23,10 +18,10 @@
  *     title="True Library Impact"
  *     subtitle="Compared against a realistic baseline app."
  *     metrics={[
- *       { value: "+561.4 KB", label: "Release APK Delta" },
- *       { value: "+440.1 KB", label: "Debug APK Delta" },
- *       { value: "4,783",     label: "Total methods",   intent: "NEUTRAL" },
- *       { value: "-32B",      label: "Manifest delta",  intent: "OK" },
+ *       { value: "+561.4 KB", label: "Release APK Delta", intent: "DANGER" },
+ *       { value: "+440.1 KB", label: "Debug APK Delta",   intent: "DANGER" },
+ *       { value: "4,783",     label: "Total methods",      intent: "NEUTRAL" },
+ *       { value: "-32B",      label: "Manifest delta",     intent: "OK" },
  *     ]}
  *   />
  */
@@ -39,8 +34,8 @@ type Metric = {
   /** Short label shown below the value, e.g. "Release APK Delta". */
   label: string;
   /**
-   * Explicit color intent for this metric.
-   * When omitted, color is auto-detected from the value string prefix.
+   * Color intent for this metric. Should always be set explicitly.
+   * Defaults to NEUTRAL (accent blue) when omitted.
    */
   intent?: ColorIntent;
 };
@@ -52,31 +47,18 @@ type Props = {
   subtitle?: string;
   /** Array of metrics to display in the grid. 2–4 items look best. */
   metrics: Metric[];
-  // NOTE: positiveIsGood removed — use explicit `intent` per metric instead.
 };
 
 const { title, subtitle, metrics } = Astro.props;
 
-function intentColor(intent: ColorIntent): string {
+function valueColor(intent?: ColorIntent): string {
   switch (intent) {
     case "DANGER":  return "text-red-500 dark:text-red-400";
     case "WARN":    return "text-orange-500 dark:text-orange-400";
     case "OK":      return "text-green-600 dark:text-green-400";
-    case "NEUTRAL": return "text-accent";
+    case "NEUTRAL":
+    default:        return "text-accent";
   }
-}
-
-function valueColor(value: string, intent?: ColorIntent): string {
-  if (intent) return intentColor(intent);
-  const isIncrease = value.trimStart().startsWith("+");
-  const isDecrease = value.trimStart().startsWith("-");
-  if (isIncrease) {
-    return "text-red-500 dark:text-red-400";
-  }
-  if (isDecrease) {
-    return "text-green-600 dark:text-green-400";
-  }
-  return "text-accent";
 }
 
 // Responsive grid: 2 cols on small screens, up to 4 on md+
@@ -113,7 +95,7 @@ const gridCols =
           <span
             class:list={[
               "text-2xl font-bold tabular-nums leading-tight",
-              valueColor(metric.value, metric.intent),
+              valueColor(metric.intent),
             ]}
           >
             {metric.value}

--- a/src/components/MetricsSummary.astro
+++ b/src/components/MetricsSummary.astro
@@ -53,7 +53,7 @@ const { title, subtitle, metrics } = Astro.props;
 
 function valueColor(intent?: ColorIntent): string {
   switch (intent) {
-    case "DANGER":  return "text-red-500 dark:text-red-400";
+    case "DANGER":  return "text-(--color-red-400)";
     case "WARN":    return "text-orange-500 dark:text-orange-400";
     case "OK":      return "text-green-600 dark:text-green-400";
     case "NEUTRAL":

--- a/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
@@ -179,10 +179,10 @@ Performance numbers are one side of the cost equation - the other is how much th
   title="True Library Impact (with-library vs baseline app)"
   subtitle="Compared against a realistic basic app that already uses WebView, LazyColumn, Canvas, and animations."
   metrics={[
-    { value: "+561.4 KB", label: "Release APK Delta" },
-    { value: "+440.1 KB", label: "Debug APK Delta" },
-    { value: "+2,708",    label: "Methods (release)" },
-    { value: "+571",      label: "Classes (release)" },
+    { value: "+561.4 KB", label: "Release APK Delta",  intent: "DANGER" },
+    { value: "+440.1 KB", label: "Debug APK Delta",    intent: "DANGER" },
+    { value: "+2,708",    label: "Methods (release)",  intent: "DANGER" },
+    { value: "+571",      label: "Classes (release)",  intent: "DANGER" },
   ]}
 />
 
@@ -192,14 +192,14 @@ The bulk of the size increase comes from the bundled Highlight.js asset (~308 KB
   title="Release Build Breakdown"
   headers={["Category", "Baseline App", "With Library", "Delta"]}
   rows={[
-    { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB" },
-    { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB" },
-    { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B" },
-    { category: "res",      values: ["36.4 KB",  "36.4 KB"],   delta: "+6B" },
-    { category: "native",   values: ["84.4 KB",  "91.4 KB"],   delta: "+7 KB" },
-    { category: "asset",    values: ["3.9 KB",   "312.5 KB"],  delta: "+308.6 KB" },
-    { category: "other",    values: ["45.2 KB",  "46 KB"],     delta: "+780B" },
-    { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB", isTotal: true },
+    { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB",  deltaIntent: "DANGER" },
+    { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB",    deltaIntent: "DANGER" },
+    { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B",        deltaIntent: "OK" },
+    { category: "res",      values: ["36.4 KB",  "36.4 KB"],   delta: "+6B",          deltaIntent: "NEUTRAL" },
+    { category: "native",   values: ["84.4 KB",  "91.4 KB"],   delta: "+7 KB",       deltaIntent: "DANGER" },
+    { category: "asset",    values: ["3.9 KB",   "312.5 KB"],  delta: "+308.6 KB",  deltaIntent: "DANGER" },
+    { category: "other",    values: ["45.2 KB",  "46 KB"],     delta: "+780B",        deltaIntent: "NEUTRAL" },
+    { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB",  deltaIntent: "DANGER", isTotal: true },
   ]}
 />
 

--- a/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
@@ -173,7 +173,7 @@ The dominant cost is the WebView JS round-trip. `ThemeParser` (CSS parsing) and 
 
 ## APK size impact
 
-Performance numbers are one side of the cost equation - the other is how much the library adds to your APK. I measured this using [diffuse](https://github.com/JakeWharton/diffuse) against a **Phase 2 enriched baseline** - a realistic app that already uses WebView, LazyColumn, Canvas, and animations - so the delta reflects only what `compose-highlight` actually brings in.
+Performance numbers are one side of the cost equation - the other is how much the library adds to your APK. I measured this using [diffuse](https://github.com/JakeWharton/diffuse) against an **enriched baseline app** - a realistic app that already uses WebView, LazyColumn, Canvas, and animations - so the delta reflects only what `compose-highlight` actually brings in.
 
 <MetricsSummary
   title="True Library Impact (with-library vs baseline app)"
@@ -189,8 +189,8 @@ Performance numbers are one side of the cost equation - the other is how much th
 The bulk of the size increase comes from the bundled Highlight.js asset (~308 KB) and the dex code for the library itself (~235 KB). The per-category breakdown:
 
 <DataTable
-  title="Phase 2 Release Breakdown"
-  headers={["Category", "Enriched Baseline", "With Library", "Delta"]}
+  title="Release Build Breakdown"
+  headers={["Category", "Baseline App", "With Library", "Delta"]}
   rows={[
     { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB" },
     { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB" },

--- a/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
@@ -8,6 +8,8 @@ draft: false
 ---
 
 import GitHubEmbed from "@/components/GitHubEmbed.astro";
+import DataTable from "@/components/DataTable.astro";
+import MetricsSummary from "@/components/MetricsSummary.astro";
 
 Recently I've been on a bit of a syntax highlighting journey on Android.
 While in [part 1](/posts/syntax-highlighting-on-android-bringing-shiki-engine-to-compose/) both cloud-based and on-device highlighting worked, I was wondering how modern apps like ChatGPT, Claude, and Perplexity handle source code highlighting on Android. The code blocks look great - proper colors, correct token boundaries, clean rendering. I was curious what was actually powering that, so I did some further investigation on their apps using good old [`apktool`](https://apktool.org/).
@@ -168,6 +170,40 @@ I added microbenchmarks using the AndroidX Benchmark library to measure the thre
 The dominant cost is the WebView JS round-trip. `ThemeParser` (CSS parsing) and `HtmlToAnnotatedString` (jsoup conversion) are sub-millisecond individually. Even large real-world files come in under 20ms, and results are cached per `rememberHighlightedCode` call so subsequent renders are free.
 
 > 💡 To reduce first-call latency, you can pre-warm the WebView renderer in `Application.onCreate()` using `WebViewCompat.startUpWebView()` from `androidx.webkit:webkit:1.16+` - which is already a transitive dependency of this library.
+
+## APK size impact
+
+Performance numbers are one side of the cost equation - the other is how much the library adds to your APK. I measured this using [diffuse](https://github.com/JakeWharton/diffuse) against a **Phase 2 enriched baseline** - a realistic app that already uses WebView, LazyColumn, Canvas, and animations - so the delta reflects only what `compose-highlight` actually brings in.
+
+<MetricsSummary
+  title="True Library Impact (with-library vs enriched baseline)"
+  subtitle="Compared against a realistic app that already uses WebView, LazyColumn, Canvas, and animations."
+  metrics={[
+    { value: "+561.4 KB", label: "Release APK Delta" },
+    { value: "+440.1 KB", label: "Debug APK Delta" },
+    { value: "+2,708",    label: "Methods (release)" },
+    { value: "+571",      label: "Classes (release)" },
+  ]}
+/>
+
+The bulk of the size increase comes from the bundled Highlight.js asset (~308 KB) and the dex code for the library itself (~235 KB). The per-category breakdown:
+
+<DataTable
+  title="Phase 2 Release Breakdown"
+  headers={["Category", "Enriched Baseline", "With Library", "Delta"]}
+  rows={[
+    { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB" },
+    { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB" },
+    { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B" },
+    { category: "res",      values: ["36.4 KB",  "36.4 KB"],   delta: "+6B" },
+    { category: "native",   values: ["84.4 KB",  "91.4 KB"],   delta: "+7 KB" },
+    { category: "asset",    values: ["3.9 KB",   "312.5 KB"],  delta: "+308.6 KB" },
+    { category: "other",    values: ["45.2 KB",  "46 KB"],     delta: "+780B" },
+    { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB", isTotal: true },
+  ]}
+/>
+
+The ~309 KB asset delta is entirely the bundled `highlight.min.js`. That is a real cost, though it compresses well in a release APK and is only loaded once during the shared `HighlightEngine` warm-up. If you were already shipping a WebView-heavy app, the marginal cost is lower than these numbers suggest - WebView itself is a system component and not included here.
 
 ## Wrapping up
 

--- a/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
@@ -176,8 +176,8 @@ The dominant cost is the WebView JS round-trip. `ThemeParser` (CSS parsing) and 
 Performance numbers are one side of the cost equation - the other is how much the library adds to your APK. I measured this using [diffuse](https://github.com/JakeWharton/diffuse) against a **Phase 2 enriched baseline** - a realistic app that already uses WebView, LazyColumn, Canvas, and animations - so the delta reflects only what `compose-highlight` actually brings in.
 
 <MetricsSummary
-  title="True Library Impact (with-library vs enriched baseline)"
-  subtitle="Compared against a realistic app that already uses WebView, LazyColumn, Canvas, and animations."
+  title="True Library Impact (with-library vs baseline app)"
+  subtitle="Compared against a realistic basic app that already uses WebView, LazyColumn, Canvas, and animations."
   metrics={[
     { value: "+561.4 KB", label: "Release APK Delta" },
     { value: "+440.1 KB", label: "Debug APK Delta" },
@@ -203,7 +203,7 @@ The bulk of the size increase comes from the bundled Highlight.js asset (~308 KB
   ]}
 />
 
-The ~309 KB asset delta is entirely the bundled `highlight.min.js`. That is a real cost, though it compresses well in a release APK and is only loaded once during the shared `HighlightEngine` warm-up. If you were already shipping a WebView-heavy app, the marginal cost is lower than these numbers suggest - WebView itself is a system component and not included here.
+The ~309 KB asset delta is entirely the bundled `highlight.min.js` and few theme files. That is a real cost, though it compresses well in a release APK and is only loaded once during the shared `HighlightEngine` warm-up. If you were already shipping a WebView-heavy app, the marginal cost is lower than these numbers suggest - WebView itself is a system component and not included here.
 
 ## Wrapping up
 

--- a/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
@@ -159,13 +159,17 @@ Text(text = (if (isDark) result?.dark else result?.light) ?: AnnotatedString(sni
 
 I added microbenchmarks using the AndroidX Benchmark library to measure the three pipeline stages. Running on a Pixel 9 Pro XL (debuggable build):
 
-| Code                      | Median  |
-| ------------------------- | ------- |
-| Python snippet            | 7.5 ms  |
-| Kotlin snippet            | 8.7 ms  |
-| SQL snippet               | 8.3 ms  |
-| ~150-line Kotlin file     | 18.8 ms |
-| ~200-line TypeScript file | 17.6 ms |
+<DataTable
+  title="Highlight Performance (Pixel 9 Pro XL, debuggable)"
+  headers={["Code", "Median"]}
+  rows={[
+    { category: "Python snippet",            values: ["7.5 ms"] },
+    { category: "Kotlin snippet",            values: ["8.7 ms"] },
+    { category: "SQL snippet",               values: ["8.3 ms"] },
+    { category: "~150-line Kotlin file",     values: ["18.8 ms"] },
+    { category: "~200-line TypeScript file", values: ["17.6 ms"] },
+  ]}
+/>
 
 The dominant cost is the WebView JS round-trip. `ThemeParser` (CSS parsing) and `HtmlToAnnotatedString` (jsoup conversion) are sub-millisecond individually. Even large real-world files come in under 20ms, and results are cached per `rememberHighlightedCode` call so subsequent renders are free.
 


### PR DESCRIPTION
## Summary

Adds two new reusable Astro components for displaying structured data inline in MDX blog posts.

---

### `DataTable`

A styled comparison table with an optional color-coded **Delta** column.

- `+` deltas → red (increase = bad by default)
- `-` deltas → green (decrease = good by default)
- Pass `positiveIsGood={true}` to invert (e.g. for performance improvements)
- Supports `isTotal: true` on rows for bold TOTAL rows
- Light + dark mode support

### `MetricsSummary`

A card with a title, optional subtitle, and a responsive grid of large highlighted metric numbers.

- 2–4 metrics render in an auto-sized grid (2-col on mobile, up to 4-col on `sm+`)
- Same `+`/`-` color logic as `DataTable`
- Values without a prefix render in the site accent color
- Light + dark mode support

---

### Docs

Updated `EMBEDS.md` with a new **Data Visualization Components** section including:
- Full usage examples for both components
- Prop tables with types and descriptions
- A combined example showing both components used together in a post

---

### Example use case (APK size analysis posts)

```mdx
import DataTable from "@/components/DataTable.astro";
import MetricsSummary from "@/components/MetricsSummary.astro";

<DataTable
  title="Release APK Breakdown"
  headers={["Category", "Baseline", "With Library", "Delta"]}
  rows={[
    { category: "dex",   values: ["676.1 KB", "1,062 KB"], delta: "+385.9 KB" },
    { category: "TOTAL", values: ["930.7 KB", "1,629 KB"], delta: "+698.7 KB", isTotal: true },
  ]}
/>

<MetricsSummary
  title="Impact Summary"
  metrics={[
    { value: "+698.7 KB", label: "Release APK (compressed)" },
    { value: "+4,783",    label: "Methods added (release)" },
  ]}
/>
```