### PR TITLE
fix: increase AI summary content limit from 6k to 15k chars

### DIFF
--- a/src/components/AiPostAssistant.astro
+++ b/src/components/AiPostAssistant.astro
@@ -196,7 +196,9 @@
   // Without this, the IIFE runs once and its DOM listeners are lost after
   // ClientRouter swaps the page content on subsequent navigations.
   document.addEventListener("astro:page-load", function () {
-    const MAX_CONTENT_CHARS = 6000;
+    // Server allows up to 20k chars. 18k covers long posts (e.g. the highlight.js
+    // post at ~14.7k) while leaving headroom for future growth.
+    const MAX_CONTENT_CHARS = 18000;
 
     // ── DOM refs ──────────────────────────────────────────────────────────────
     const toggle = document.getElementById("ai-toggle") as HTMLButtonElement | null;


### PR DESCRIPTION
The highlight.js post is ~14.7k characters but the client-side extractor caps at 6k, so the AI never sees the full post. Bumping to 15k covers this post and most others while staying well under the server's 20k limit.