### PR TITLE
fix: increase AI content limits to 30k server / 25k client

### DIFF
--- a/src/components/AiPostAssistant.astro
+++ b/src/components/AiPostAssistant.astro
@@ -196,9 +196,9 @@
   // Without this, the IIFE runs once and its DOM listeners are lost after
   // ClientRouter swaps the page content on subsequent navigations.
   document.addEventListener("astro:page-load", function () {
-    // Server allows up to 20k chars. 18k covers long posts (e.g. the highlight.js
+    // Server allows up to 30k chars. 25k covers long posts (e.g. the highlight.js
     // post at ~14.7k) while leaving headroom for future growth.
-    const MAX_CONTENT_CHARS = 18000;
+    const MAX_CONTENT_CHARS = 25000;
 
     // ── DOM refs ──────────────────────────────────────────────────────────────
     const toggle = document.getElementById("ai-toggle") as HTMLButtonElement | null;

--- a/src/pages/api/ai-chat.ts
+++ b/src/pages/api/ai-chat.ts
@@ -5,9 +5,9 @@ export const prerender = false;
 
 // Maximum characters of post content to send to the model.
 // gemma-4-26b-a4b-it has a 256,000 token context window - far more than enough for any blog post.
-// 20,000 chars (~5,000 tokens) covers full blog posts without truncation while keeping costs reasonable.
+// 30,000 chars (~7,500 tokens) ensures even very long posts are sent in full while keeping costs reasonable.
 // Raise this if posts are truncated, or lower it to reduce per-request token cost.
-const MAX_CONTENT_LENGTH = 20_000;
+const MAX_CONTENT_LENGTH = 30_000;
 
 export const POST: APIRoute = async ({ request }) => {
   // Only accept JSON


### PR DESCRIPTION
Bumps server truncation from 20k → 30k chars and client extraction from 18k → 25k chars to ensure even very long posts are sent in full without cutting off content. Updates comments to reflect new limits.

* Followup from #63 