### PR TITLE
Add Node.js version 25.x to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 25.x]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
This pull request updates the Node.js versions used in the CI workflow to include Node.js 25.x in addition to the previously tested versions.

* CI workflow update:
  * [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL19-R19): Added Node.js 25.x to the test matrix to ensure compatibility with the latest Node.js release.