### PR TITLE
feat: add draft post on Shiki highlighting for Zensical

### DIFF
--- a/src/data/blog/better-kotlin-syntax-highlighting-zensical-shiki.mdx
+++ b/src/data/blog/better-kotlin-syntax-highlighting-zensical-shiki.mdx
@@ -144,6 +144,9 @@ After this update, Kotlin snippets are much more readable on my docs site, espec
 
 The nice part is I got this improvement without rewriting my full docs rendering stack.
 
+> [!WARNING]
+> Add before and after screenshots here so readers can quickly see what improved.
+
 If you want to see the exact implementation details and notes, check issue [#128](https://github.com/hossain-khan/android-compose-highlight/issues/128) and PR [#129](https://github.com/hossain-khan/android-compose-highlight/pull/129).
 
 If you find any issue, open a GitHub issue. Hope it helps somebody. ✌️

--- a/src/data/blog/better-kotlin-syntax-highlighting-zensical-shiki.mdx
+++ b/src/data/blog/better-kotlin-syntax-highlighting-zensical-shiki.mdx
@@ -1,0 +1,149 @@
+---
+title: Better Kotlin syntax highlighting on Zensical with Shiki
+description: I replaced default Kotlin highlighting on my Zensical site with Shiki for cleaner tokens, better modern syntax support, and smooth light/dark theming.
+pubDatetime: 2026-05-29T12:00:00Z
+tags: ["kotlin", "shiki", "syntax-highlighting", "zensical", "documentation"]
+featured: false
+draft: true
+---
+
+Recently I used Zensical for my new Compose Highlight library, and I noticed Kotlin syntax highlighting was not fully accurate. I did a quick search to see if I could change the highlighting pipeline on a Zensical site, but I could not find much documentation. Then I asked in the Discord community, and someone shared a helpful clue in this thread: [Shiki highlighting discussion](https://discord.com/channels/1289187620659789824/1506439799500701768/1506439799500701768). That pointed me to a Shiki-based JavaScript approach that worked really well.
+
+My site already had build-time highlighting with Pygments, so this was not a "nothing works" problem. It was more of a "this works, but Kotlin deserves better" kind of problem. You can see the live docs site here: [android-compose-highlight docs](https://hossain-khan.github.io/android-compose-highlight/).
+
+In this post, I will share how I added Shiki support for Kotlin code blocks without breaking the existing Zensical code block UI.
+
+> [!IMPORTANT]
+> Zensical is still in an early stage. At the time of writing this post, the current release is `0.0.43`. There may be a native way to handle this in a future release, so treat this approach as a practical workaround for now.
+
+## Where things felt off
+
+Pygments is fast and reliable for static builds, but its Kotlin lexer is regex-based. I noticed it sometimes misses context that matters for clean Kotlin highlighting.
+
+Things I wanted to improve:
+
+- Better distinction between types, variables, and keywords
+- Better support for modern Kotlin syntax
+- Consistent colors between light and dark theme
+
+I did not want to replace everything though. I only wanted to improve Kotlin blocks and keep the rest of the site behavior unchanged.
+
+## What I decided to try
+
+I took a hybrid approach:
+
+1. Keep Pygments as the default highlighter for all languages at build time
+2. Re-highlight only Kotlin blocks on the client side with Shiki
+3. Preserve the existing `<pre>` and wrapper structure so copy buttons and layout keep working
+
+That gave me better Kotlin tokenization while keeping the stability of the current Zensical pipeline.
+
+> 💡 Tip: If your docs site already has working build-time highlighting, this incremental approach is much safer than swapping the whole highlighting system in one go.
+
+## What I changed in the repo
+
+I changed just three files:
+
+- `docs/javascripts/shiki-kotlin.js` (new)
+- `docs/stylesheets/shiki-kotlin.css` (new)
+- `zensical.toml` (updated to load both assets)
+
+The related issue and PR are here:
+
+- Issue [#128](https://github.com/hossain-khan/android-compose-highlight/issues/128)
+- PR [#129](https://github.com/hossain-khan/android-compose-highlight/pull/129)
+
+## How the JavaScript part works
+
+The script scans code blocks, detects Kotlin blocks, asks Shiki to render highlighted HTML, then swaps only the inner `<code>` content.
+
+That "swap only inner HTML" decision mattered a lot for me because Zensical's existing wrappers handle extra UI behavior (like copy actions). Replacing the whole block would have been risky.
+
+Here is a simplified version of the core flow:
+
+```js
+import { createHighlighter } from "shiki";
+
+const highlighter = await createHighlighter({
+  langs: ["kotlin"],
+  themes: ["one-light", "one-dark-pro"],
+});
+
+function highlightKotlinBlocks() {
+  const blocks = document.querySelectorAll("pre code");
+
+  for (const block of blocks) {
+    if (!block.classList.contains("language-kotlin")) continue;
+
+    const source = block.textContent ?? "";
+    const html = highlighter.codeToHtml(source, {
+      lang: "kotlin",
+      themes: {
+        light: "one-light",
+        dark: "one-dark-pro",
+      },
+      defaultColor: false,
+    });
+
+    const temp = document.createElement("div");
+    temp.innerHTML = html;
+
+    const shikiPre = temp.querySelector("pre");
+    const shikiCode = temp.querySelector("code");
+    const existingPre = block.closest("pre");
+
+    if (!shikiPre || !shikiCode || !existingPre) continue;
+
+    block.innerHTML = shikiCode.innerHTML;
+
+    const shikiStyle = shikiPre.getAttribute("style") || "";
+    const cssVars = shikiStyle.match(/--shiki[^;]+;?/g) || [];
+    existingPre.style.cssText += cssVars.join("");
+  }
+}
+```
+
+I also wired this into Zensical's SPA navigation lifecycle, so highlighting still runs after route transitions.
+
+## How I handled theme and CSS
+
+For theming, I used Shiki's CSS variables with `defaultColor: false`. That embeds both light and dark token values as variables, so switching theme is instant.
+
+I also added a small CSS fix for blank line rendering, because line wrappers can collapse visually if you do not style them explicitly.
+
+```css
+.shiki code {
+  display: grid;
+}
+
+.shiki code > span {
+  min-height: 1.4em;
+}
+```
+
+Nothing fancy here, but this tiny part saved me from weird line spacing and "missing" empty lines.
+
+## Issues I hit and fixed
+
+These are the issues I hit while wiring this up:
+
+- Kotlin blocks did not re-highlight on client-side navigation until I subscribed to the SPA transition hook
+- Replacing entire `<pre>` broke some existing code block behavior
+- Without `defaultColor: false`, light/dark switching was not as smooth as I wanted
+- I first tried selecting `code.language-kotlin`, then noticed Zensical puts the language class on the wrapper div (`div.language-kotlin.highlight`), so selector targeting matters
+- If I applied Shiki background color vars to `<pre>`, Zensical's code block background looked wrong and copy buttons felt visually detached
+- Shiki wraps lines in `.line` spans, and blank lines collapsed until I forced block rendering with a minimum line height
+
+If you hit similar issues, start by preserving existing DOM wrappers and only replacing the minimum possible HTML.
+
+> 💡 Tip: Two things gave me the cleanest result - keep Zensical in charge of the code block container styles, and let Shiki handle token colors only.
+
+## How it turned out
+
+After this update, Kotlin snippets are much more readable on my docs site, especially for newer syntax and mixed DSL-style code.
+
+The nice part is I got this improvement without rewriting my full docs rendering stack.
+
+If you want to see the exact implementation details and notes, check issue [#128](https://github.com/hossain-khan/android-compose-highlight/issues/128) and PR [#129](https://github.com/hossain-khan/android-compose-highlight/pull/129).
+
+If you find any issue, open a GitHub issue. Hope it helps somebody. ✌️


### PR DESCRIPTION
## Summary
- Add a new draft MDX post: `Better Kotlin syntax highlighting on Zensical with Shiki`
- Explain the motivation, approach, and Kotlin-only Shiki enhancement
- Include references to issue #128, PR #129, Discord thread, and live docs site
- Keep the post as draft for further review

## Changes
- Added `src/data/blog/better-kotlin-syntax-highlighting-zensical-shiki.mdx`
- Added a warning callout reminder to include before/after screenshots
- Set frontmatter `draft: true`

## Notes
- Content-only change
- No site functionality changes

## Related
- Issue - https://github.com/hossain-khan/android-compose-highlight/issues/128
- PR - https://github.com/hossain-khan/android-compose-highlight/pull/129