### PR TITLE
fix: link compose highlight mention to related post

### DIFF
--- a/src/data/blog/better-kotlin-syntax-highlighting-zensical-shiki.mdx
+++ b/src/data/blog/better-kotlin-syntax-highlighting-zensical-shiki.mdx
@@ -7,7 +7,7 @@ featured: false
 draft: false
 ---
 
-Recently, I used [Zensical](https://zensical.org/) for my new Compose Highlight library and noticed Kotlin syntax highlighting was not fully accurate. 
+Recently, I used [Zensical](https://zensical.org/) for my [new Compose Highlight library](/posts/syntax-highlighting-on-android-highlight-js-native-compose-engine/) and noticed Kotlin syntax highlighting was not fully accurate. 
 I did a quick search to see whether I could change the highlighting pipeline on a Zensical site, but I could not find much documentation. 
 Then I asked in the Discord community, and someone shared a helpful clue in this thread: [Shiki highlighting discussion](https://discord.com/channels/1289187620659789824/1506439799500701768/1506439799500701768). 
 That pointed me to a Shiki-based JavaScript approach that worked really well.


### PR DESCRIPTION
Link the "new Compose Highlight library" mention in the Zensical Shiki post to the related Compose Highlight article so readers can jump to the follow-up post directly.