### PR TITLE
chore: add AGENTS.md symlink to copilot instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md


### PR DESCRIPTION
Creates a symlink `AGENTS.md` pointing to `.github/copilot-instructions.md` so AI coding assistants can discover project conventions from the repo root.