### PR TITLE
chore: add explicit start/end logs to atmosphere sync script

### DIFF
--- a/scripts/publishToAtmosphere.ts
+++ b/scripts/publishToAtmosphere.ts
@@ -43,6 +43,8 @@ import { SITE } from "../src/config";
 
 /* eslint-disable no-console */
 
+console.log("🚀 Starting atmosphere sync...");
+
 /** Directory where blog posts are stored (relative to project root) */
 const BLOG_DIR = "src/data/blog";
 
@@ -128,6 +130,7 @@ await createOrUpdateStandardSite(session, publication, docs, {
 });
 
 console.log("Atmosphere sync complete");
+console.log("✅ Atmosphere sync complete — records published to ATmosphere");
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/scripts/publishToAtmosphere.ts
+++ b/scripts/publishToAtmosphere.ts
@@ -29,6 +29,10 @@
  *
  * Environment variables:
  *   ATPROTO_PASSWORD  - Bluesky app-specific password (https://bsky.app/settings/app-passwords)
+ * 
+ * Additional references:
+ *   - https://mastrojs.github.io/blog/2026-06-05-how-to-add-standard-site-support-to-your-website/
+ *   - https://github.com/mastrojs/atproto
  */
 
 import path from "node:path";


### PR DESCRIPTION
Adds clear log markers at the beginning and end of `scripts/publishToAtmosphere.ts` so it's unmistakable in Cloudflare build logs that the sync step ran.\n\n**Before:**\n```\nFound 18 posts to sync\nAtmosphere sync complete\n```\n\n**After:**\n```\n🚀 Starting atmosphere sync...\nFound 18 posts to sync\nAtmosphere sync complete\n✅ Atmosphere sync complete — records published to ATmosphere\n```\n\nThis makes it easy to grep for `atmosphere sync` in the build log and confirm the step executed.