### PR TITLE
chore: run atmosphere sync before astro build for visible logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "astro dev",
-    "build": "wrangler types && astro check && astro build && pagefind --site dist/client && cp -r dist/client/pagefind public/ && node --import tsx scripts/publishToAtmosphere.ts",
+    "build": "wrangler types && astro check && node --import tsx scripts/publishToAtmosphere.ts && astro build && pagefind --site dist/client && cp -r dist/client/pagefind public/",
     "sync:atmosphere": "node --import tsx scripts/publishToAtmosphere.ts",
     "preview": "astro preview",
     "sync": "astro sync",


### PR DESCRIPTION
Moves the sync script earlier in the build chain so its console output is clearly visible in Cloudflare build logs.\n\n

**Before:**
```
wrangler types && astro check && astro build && pagefind ... && node scripts/publishToAtmosphere.ts
```

**After:**

```\nwrangler types && astro check && node scripts/publishToAtmosphere.ts && astro build && pagefind ...```

Now the sync runs before `astro build`, so:\n1. Console logs (`🚀 Starting...`, `✅ Complete`) are visible in Cloudflare build output\n2. The `.well-known` file gets copied to `dist/client/` naturally by Astro\n3. No more guessing whether the script executed