### PR TITLE
docs: update composeHighlight metrics

### DIFF
--- a/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
+++ b/src/data/blog/syntax-highlighting-on-android-highlight-js-native-compose-engine.mdx
@@ -12,10 +12,10 @@ import DataTable from "@/components/DataTable.astro";
 import MetricsSummary from "@/components/MetricsSummary.astro";
 
 Recently I've been on a bit of a syntax highlighting journey on Android.
-While in [part 1](/posts/syntax-highlighting-on-android-bringing-shiki-engine-to-compose/) both cloud-based and on-device highlighting worked, I was wondering how modern apps like ChatGPT, Claude, and Perplexity handle source code highlighting on Android. 
+While in [part 1](/posts/syntax-highlighting-on-android-bringing-shiki-engine-to-compose/) both cloud-based and on-device highlighting worked, I was wondering how modern apps like ChatGPT, Claude, and Perplexity handle source code highlighting on Android.
 Their code blocks UI look great - proper colors, correct token boundaries, clean rendering. I was curious to know how they have done it, so I peeked inside their apps using good old [`apktool`](https://apktool.org/).
 
-The answer was surprisingly simple, those apps uses **Highlight.js running inside a hidden WebView**. The tokenized HTML output like `<span class="hljs-*">` elements is then parsed and mapped to native Compose `AnnotatedString` spans. 
+The answer was surprisingly simple, those apps uses **Highlight.js running inside a hidden WebView**. The tokenized HTML output like `<span class="hljs-*">` elements is then parsed and mapped to native Compose `AnnotatedString` spans.
 The `WebView` never actually renders anything visible. It just does the parsing work in the background, and the result is fully native text that supports real text selection and accessibility and more out of the box.
 
 This finding was interesting enough that I decided to experiment with it and build a proof-of-concept library for Jetpack Compose along with sample app to showcase the usage.
@@ -171,10 +171,10 @@ I added microbenchmarks using the AndroidX Benchmark library to measure the thre
   title="Highlight Performance (Pixel 9 Pro XL, debuggable)"
   headers={["Code", "Median"]}
   rows={[
-    { category: "Python snippet",            values: ["7.5 ms"] },
-    { category: "Kotlin snippet",            values: ["8.7 ms"] },
-    { category: "SQL snippet",               values: ["8.3 ms"] },
-    { category: "~150-line Kotlin file",     values: ["18.8 ms"] },
+    { category: "Python snippet", values: ["7.5 ms"] },
+    { category: "Kotlin snippet", values: ["8.7 ms"] },
+    { category: "SQL snippet", values: ["8.3 ms"] },
+    { category: "~150-line Kotlin file", values: ["18.8 ms"] },
     { category: "~200-line TypeScript file", values: ["17.6 ms"] },
   ]}
 />
@@ -185,37 +185,54 @@ The dominant cost is the WebView JS round-trip. `ThemeParser` (CSS parsing) and 
 
 ## APK size impact
 
-Performance numbers are one side of the cost equation - the other is how much the library adds to your APK. I measured this using [diffuse](https://github.com/JakeWharton/diffuse) against an **enriched baseline app** - a realistic single activity app that already uses `WebView`, `LazyColumn`, `Canvas`, and animations - so the delta reflects only what `compose-highlight` library actually brings in.
+Performance numbers are one side of the cost equation - the other is how much the library adds to your APK. I measured this using [diffuse](https://github.com/JakeWharton/diffuse) and `bundletool get-size` against the `none` baseline on `arm64-v8a`, `xxhdpi`, `en`.
 
 <MetricsSummary
-  title="True Library Impact (with-library vs baseline app)"
-  subtitle="Compared against a realistic basic app that already uses WebView, LazyColumn, Canvas, and animations."
+  title="Latest composeHighlight impact"
+  subtitle="Measured with the single-tree flavor methodology on the latest report."
   metrics={[
-    { value: "+561.4 KB", label: "Release APK Delta",  intent: "DANGER" },
-    { value: "+440.1 KB", label: "Debug APK Delta",    intent: "DANGER" },
-    { value: "+2,708",    label: "Methods (release)",  intent: "DANGER" },
-    { value: "+571",      label: "Classes (release)",  intent: "DANGER" },
+    { value: "+853.2 KB", label: "Download delta", intent: "DANGER" },
+    { value: "1.73 MB", label: "Diff-APK total", intent: "DANGER" },
+    { value: "+1,546", label: "Classes kept", intent: "DANGER" },
+    { value: "+78,709", label: "Methods kept", intent: "DANGER" },
   ]}
 />
 
-The bulk of the size increase comes from the bundled Highlight.js asset (~308 KB) and the dex code for the library itself (~235 KB). The per-category breakdown:
+The bulk of the footprint still sits in the bundled Highlight.js asset and the library dex code. The latest measurements for `composeHighlight` look like this:
 
 <DataTable
-  title="Release Build Breakdown"
-  headers={["Category", "Baseline App", "With Library", "Delta"]}
+  title="composeHighlight latest measurement"
+  headers={[
+    "Usage",
+    "Download size",
+    "Total bytes",
+    "Classes",
+    "Methods",
+    "Delta vs none",
+  ]}
   rows={[
-    { category: "dex",      values: ["826.1 KB", "1 MB"],      delta: "+235.9 KB",  deltaIntent: "DANGER" },
-    { category: "arsc",     values: ["70.2 KB",  "79.3 KB"],   delta: "+9.1 KB",    deltaIntent: "DANGER" },
-    { category: "manifest", values: ["1.7 KB",   "1.7 KB"],    delta: "-32B",        deltaIntent: "OK" },
-    { category: "res",      values: ["36.4 KB",  "36.4 KB"],   delta: "+6B",          deltaIntent: "NEUTRAL" },
-    { category: "native",   values: ["84.4 KB",  "91.4 KB"],   delta: "+7 KB",       deltaIntent: "DANGER" },
-    { category: "asset",    values: ["3.9 KB",   "312.5 KB"],  delta: "+308.6 KB",  deltaIntent: "DANGER" },
-    { category: "other",    values: ["45.2 KB",  "46 KB"],     delta: "+780B",        deltaIntent: "NEUTRAL" },
-    { category: "TOTAL",    values: ["1 MB",     "1.6 MB"],    delta: "+561.4 KB",  deltaIntent: "DANGER", isTotal: true },
+    {
+      category: "minimal",
+      values: ["1.56 MB", "1.73 MB", "3,766", "200,123"],
+      delta: "+853.2 KB",
+      deltaIntent: "DANGER",
+    },
+    {
+      category: "typical",
+      values: ["1.57 MB", "1.73 MB", "3,767", "200,151"],
+      delta: "+854.4 KB",
+      deltaIntent: "DANGER",
+    },
+    {
+      category: "maximal",
+      values: ["1.57 MB", "1.73 MB", "3,767", "200,213"],
+      delta: "+854.5 KB",
+      deltaIntent: "DANGER",
+    },
   ]}
 />
 
-The ~309 KB asset delta is entirely the bundled `highlight.min.js` and few theme files. That is a real cost, though it compresses well in a release APK and is only loaded once during the shared `HighlightEngine` warm-up. If you were already shipping a WebView-heavy app, the marginal cost is lower than these numbers suggest - WebView itself is a system component and not included here.
+The `composeHighlight` bundle includes roughly `190` languages in a single `highlight.min.js` asset, so the language count stays fixed even as the usage level changes. The reachability gap between `minimal` and `maximal` is just `1,256 B`, which is consistent with the report's note that consumer keep rules force-keep most of the public surface.
 
 ## What's new since this post
 


### PR DESCRIPTION
Refresh the APK-size section in the composeHighlight article to match the latest report:
- update the summary metrics
- replace the old baseline-app breakdown with the new single-tree flavor measurements
- note the 190 bundled languages and the 1,256 B reachability gap