### PR TITLE
fix: normalize logo alignment across browsers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ Below is a summary of all changes and visual improvements implemented in the blo
 
 ### Recent Modifications
 
+- **Jun 12, 2026** - `35e4312`: fix: normalize logo SVG text alignment across browsers
+  > *Replaced the `bytes` portion of the logo from a `tspan` using `baseline-shift` to a plain SVG text node with explicit coordinates. This avoids Firefox's inconsistent SVG baseline handling and keeps the header logo aligned the same way as Chrome during normal and hover states.*
+
 - **Jun 06, 2026** - `<pending>`: feat: add Standard.site support for Bluesky "View publication" button
   > *Integrated `@mastrojs/atproto` to sync blog posts to the ATmosphere (ATproto network). Each post page now includes a `<link rel="site.standard.document">` tag, and a build-time script creates/updates Standard.site records on Bluesky. When links are shared on Bluesky, readers see a "View publication" button with rich metadata. rkeys are derived from URL paths so no frontmatter changes are needed.*
 

--- a/src/assets/logo/hkdevbytes.svg
+++ b/src/assets/logo/hkdevbytes.svg
@@ -3,7 +3,7 @@
   <g transform="matrix(1.112155, 0, 0, 1.112155, 12.50231, -14.050506)" id="object-0">
     <text class="logo-text-left" style="fill: rgb(51, 51, 51); font-family: var(--font-cascadia-code), 'Cascadia Code', monospace; font-size: 150px; font-weight: 600; white-space: pre;" x="0" y="176.957">hk</text>
     <text class="logo-sphere" style="fill: rgb(167, 90, 90); font-family: var(--font-cascadia-code), 'Cascadia Code', monospace; font-size: 150px; font-weight: 600; letter-spacing: -30px; paint-order: stroke; white-space: pre; transform-origin: 342.846px 129.448px;" x="190" y="176.957">{·}</text>
-    <text class="logo-text-right" style="fill: rgb(51, 51, 51); font-family: var(--font-cascadia-code), 'Cascadia Code', monospace; font-size: 150px; font-weight: 600; white-space: pre; transform-origin: -123.373px 8.755px;"><tspan x="395" y="89.954" style="baseline-shift: sub;">bytes</tspan></text>
+    <text class="logo-text-right" style="fill: rgb(51, 51, 51); font-family: var(--font-cascadia-code), 'Cascadia Code', monospace; font-size: 150px; font-weight: 600; white-space: pre;" x="395" y="176.957">bytes</text>
   </g>
   <defs>
     <bx:export>


### PR DESCRIPTION
## Summary
- replace the logo SVG's browser-dependent baseline-shift usage with explicit text positioning
- keep the header logo aligned consistently between Firefox and Chrome in default and hover states
- document the fix in the changelog

## Testing
- not run in Codex sandbox because Cloudflare/Wrangler verification is blocked by sandbox permissions
